### PR TITLE
Update petsc git url since petsc moved to gitlab

### DIFF
--- a/install_external_libs/install_petsc.sh
+++ b/install_external_libs/install_petsc.sh
@@ -17,7 +17,7 @@ cd ~/SLlibs;
 
 echo '__________________________________________';
 echo 'FETCHING THE LATEST PETSC VERSION FROM GIT';
-git clone -b maint https://bitbucket.org/petsc/petsc petsc;
+git clone -b maint https://gitlab.com/petsc/petsc petsc;
 
 
 ########## CONFIGURE PETSC (SELECT THE APPROPRIATE CONFIGURATION OPTIONS BELOW) :


### PR DESCRIPTION
PETSc has moved to Gitlab (instead of Bitbucket). This PR updates the URL in the install script