### PR TITLE
Build library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,14 @@ endif
 # D can be added to all of the above.
 
 CXX = g++ -fopenmp # openmp is used for parallel sorting on Linux
-CXX_FLAGS= -std=c++11 -O3 -Wno-return-type # Do not warn when not returning anything (e.g. in virtual functions)
+CXX_FLAGS= -std=c++11 -O3 -Wno-return-type -fPIC # Do not warn when not returning anything (e.g. in virtual functions)
 
 # List of all directories containing the headers:
 INCLUDES = -I src -I src/field -I src/expression -I src/expression/operation -I src/shapefunction -I src/formulation -I src/shapefunction/hierarchical -I src/shapefunction/hierarchical/h1 -I src/shapefunction/hierarchical/hcurl -I src/shapefunction/hierarchical/meca -I src/gausspoint -I src/shapefunction/lagrange -I src/mesh -I src/io -I src/io/gmsh -I src/io/paraview -I src/io/nastran -I src/resolution -I src/geometry
+
 # List of all .cpp source files:
 CPPS= $(wildcard src/*.cpp) $(wildcard src/field/*.cpp) $(wildcard src/expression/*.cpp) $(wildcard src/expression/operation/*.cpp) $(wildcard src/shapefunction/*.cpp) $(wildcard src/formulation/*.cpp) $(wildcard src/shapefunction/hierarchical/*.cpp) $(wildcard src/shapefunction/hierarchical/h1/*.cpp) $(wildcard src/shapefunction/hierarchical/meca/*.cpp) $(wildcard src/shapefunction/hierarchical/hcurl/*.cpp) $(wildcard src/gausspoint/*.cpp) $(wildcard src/shapefunction/lagrange/*.cpp) $(wildcard src/mesh/*.cpp) $(wildcard src/io/*.cpp) $(wildcard src/io/gmsh/*.cpp) $(wildcard src/io/paraview/*.cpp) $(wildcard src/io/nastran/*.cpp) $(wildcard src/resolution/*.cpp) $(wildcard src/geometry/*.cpp)
+
 # Final binary name:
 BIN = sparselizard
 # Put all generated stuff to this build directory:
@@ -42,7 +44,7 @@ OBJECTS=$(CPPS:%.cpp=$(BUILD_DIR)/%.o)
 # Gcc/Clang will create these .d files containing dependencies.
 DEP = $(OBJECTS:%.o=%.d)
 
-all: $(OBJECTS)
+all: $(OBJECTS) libsparselizard.so
 	# The main is always recompiled (it could have been replaced):
 	$(CXX) $(CXX_FLAGS) $(LIBS) $(INCL) $(INCLUDES) -c main.cpp -o $(BUILD_DIR)/main.o
 	# Linking objects:
@@ -62,3 +64,9 @@ clean :
     # Removes all files created.
 	rm -rf $(BUILD_DIR)
 	rm -f $(BIN)
+
+# make shared library
+LDFLAGS= -shared
+libsparselizard.so : $(OBJECTS)
+	 $(CC) $(CFLAGS) $(OBJECTS) -o $@ $(LDFLAGS)
+

--- a/examples/Makefile.example
+++ b/examples/Makefile.example
@@ -1,0 +1,72 @@
+# Makefile to build example and link to shared library
+#
+# ~~~
+# How to use this file
+#
+# > cd [example]
+# > make -f ../Makefile.example
+# > bash ../run.sh
+# ~~~
+
+##### THESE ARE THE REQUIRED LIBRARIES:
+
+UNAME := $(shell uname)
+
+ifeq ($(UNAME), Linux)
+LIBS = -L ~/SLlibs/petsc/arch-linux2-c-opt/lib -l openblas -l petsc -l slepc
+INCL = -I ~/SLlibs/petsc/include/petsc/mpiuni -I ~/SLlibs/petsc/arch-linux2-c-opt/externalpackages/git.openblas -I ~/SLlibs/petsc/include/ -I ~/SLlibs/petsc/arch-linux2-c-opt/include/
+endif
+ifeq ($(UNAME), Darwin)
+LIBS = -L ~/SLlibs/petsc/arch-darwin-c-opt/lib -l openblas -l petsc -l slepc
+INCL = -I ~/SLlibs/petsc/include/petsc/mpiuni -I ~/SLlibs/petsc/arch-darwin-c-opt/externalpackages/git.openblas -I ~/SLlibs/petsc/include/ -I ~/SLlibs/petsc/arch-darwin-c-opt/include/
+endif
+
+
+# $@ is the filename representing the target.
+# $< is the filename of the first prerequisite.
+# $^ the filenames of all the prerequisites.
+# $(@D) is the file path of the target file. 
+# D can be added to all of the above.
+
+CXX = g++ -fopenmp # openmp is used for parallel sorting on Linux
+CXX_FLAGS= -std=c++11 -O3 -Wno-return-type # Do not warn when not returning anything (e.g. in virtual functions)
+
+# base location of the source files
+PREFIX = ~/Desktop/sparselizard
+
+# add path to libsparselizard.so
+LIBS += -L ${PREFIX} -l sparselizard
+
+# List of all directories containing the headers:
+INCLUDES = \
+-I $(PREFIX)/src \
+-I $(PREFIX)/src/field \
+-I $(PREFIX)/src/expression \
+-I $(PREFIX)/src/expression/operation \
+-I $(PREFIX)/src/shapefunction \
+-I $(PREFIX)/src/formulation \
+-I $(PREFIX)/src/shapefunction/hierarchical \
+-I $(PREFIX)/src/shapefunction/hierarchical/h1 \
+-I $(PREFIX)/src/shapefunction/hierarchical/hcurl \
+-I $(PREFIX)/src/shapefunction/hierarchical/meca \
+-I $(PREFIX)/src/gausspoint \
+-I $(PREFIX)/src/shapefunction/lagrange \
+-I $(PREFIX)/src/mesh \
+-I $(PREFIX)/src/io \
+-I $(PREFIX)/src/io/gmsh \
+-I $(PREFIX)/src/io/paraview \
+-I $(PREFIX)/src/io/nastran \
+-I $(PREFIX)/src/resolution \
+-I $(PREFIX)/src/geometry
+
+# Final binary name:
+BIN = main
+
+all: $(OBJECTS)
+	# The main is always recompiled (it could have been replaced):
+	$(CXX) $(CXX_FLAGS) $(LIBS) $(INCL) $(INCLUDES) -c main.cpp -o main.o
+	# Linking objects:
+	$(CXX) main.o $(OBJECTS) $(LIBS) -o $(BIN)
+	
+clean :
+	rm -f main main.o

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Simple wrapper to set library paths without admin
+#
+# ~~~
+# How to use this file
+#
+# > cd [example]
+# > make -f ../Makefile.example
+# > bash ../run.sh
+# ~~~
+
+
+# LOAD REQUIRED LIBRARIES:
+
+if [ "$(uname)" == "Linux" ]; then
+LD_LIBRARY_PATH="$HOME/SLlibs/petsc/arch-linux2-c-opt/lib:$HOME/Desktop/sparselizard":$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+elif [ "$(uname)" == "Darwin"  ]; then
+DYLD_LIBRARY_PATH="$HOME/SLlibs/petsc/arch-darwin-c-opt/lib":$DYLD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH
+fi
+
+
+# Run executable
+./main


### PR DESCRIPTION
These two scripts help a bit on running the examples one by one and to create new projects based on them.
Using a shared library and the include headers seems more natural to me.
It probably won't work on macOS as the -fPIC and -shared flags must be something else.