### PR TITLE
Fix compiler warnings #1 (useless semicolon and signed/unsigned comparison)

### DIFF
--- a/src/densematrix.cpp
+++ b/src/densematrix.cpp
@@ -62,7 +62,7 @@ densematrix::densematrix(std::vector<densematrix> input)
     // Calculate the final concatenated size:
     numcols = input[0].countcolumns();
     numrows = input[0].countrows();
-    for (long long int i = 1; i < input.size(); i++)
+    for (size_t i = 1; i < input.size(); i++)
     {
         numrows += input[i].countrows();
         if (input[i].countcolumns() != numcols)
@@ -74,7 +74,7 @@ densematrix::densematrix(std::vector<densematrix> input)
     double* myvaluesptr = new double[numrows*numcols];
     
     long long int index = 0;
-    for (long long int i = 0; i < input.size(); i++)
+    for (size_t i = 0; i < input.size(); i++)
     {
         double* curvals = input[i].getvalues();
         for (long long int j = 0; j < input[i].count(); j++)
@@ -120,7 +120,7 @@ void densematrix::insertatrows(std::vector<int> selectedrows, densematrix toinse
     double* myvaluesptr = myvalues.get();
     double* toinsertvaluesptr = toinsert.myvalues.get();
     
-    for (long long int i = 0; i < selectedrows.size(); i++)
+    for (size_t i = 0; i < selectedrows.size(); i++)
     {
         for (long long int col = 0; col < numcols; col++)
             myvaluesptr[selectedrows[i]*numcols+col] = toinsertvaluesptr[i*numcols+col];
@@ -134,7 +134,7 @@ void densematrix::insertatcolumns(std::vector<int> selectedcolumns, densematrix 
     
     for (long long int row = 0; row < numrows; row++)
     {
-        for (long long int j = 0; j < selectedcolumns.size(); j++)
+        for (size_t j = 0; j < selectedcolumns.size(); j++)
             myvaluesptr[row*numcols+selectedcolumns[j]] = toinsertvaluesptr[row*toinsert.numcols+j];
     }
 }
@@ -704,7 +704,7 @@ densematrix densematrix::extractcols(std::vector<int> selected)
 densematrix densematrix::extractrows(long long int rangebegin, long long int rangeend)
 {
     std::vector<int> selected(rangeend-rangebegin+1);
-    for (long long int i = 0; i < selected.size(); i++)
+    for (size_t i = 0; i < selected.size(); i++)
         selected[i] = rangebegin + i;
         
     return extractrows(selected);
@@ -713,7 +713,7 @@ densematrix densematrix::extractrows(long long int rangebegin, long long int ran
 densematrix densematrix::extractcols(long long int rangebegin, long long int rangeend)
 {
     std::vector<int> selected(rangeend-rangebegin+1);
-    for (long long int i = 0; i < selected.size(); i++)
+    for (size_t i = 0; i < selected.size(); i++)
         selected[i] = rangebegin + i;
         
     return extractcols(selected);

--- a/src/element.cpp
+++ b/src/element.cpp
@@ -1416,7 +1416,7 @@ void element::fullsplit(int n, std::vector<std::vector<double>>& splitcoords, st
     }
     
     // Populate:
-    int index = 0;
+    size_t index = 0;
     for (int e = 0; e < ne; e++)
     {
         std::vector<double> coords(3*ncn);
@@ -1431,7 +1431,7 @@ void element::fullsplit(int n, std::vector<std::vector<double>>& splitcoords, st
         {
             std::vector<double> cursplit = calculatecoordinates(curvedsubcoords[throughedgenum][i], coords);
 
-            for (int j = 0; j < cursplit.size(); j++)
+            for (size_t j = 0; j < cursplit.size(); j++)
                 splitcoords[tn][index+j] = cursplit[j];
             index += cursplit.size();
         }
@@ -1455,7 +1455,7 @@ void element::fullsplit(int n, std::vector<std::vector<double>>& splitcoords, st
             curvedtetsubcoords[i] = mystraighttet.calculatecoordinates(curvedtetrefcoords, cc);
         }
     
-        int index = 0;
+        size_t index = 0;
         for (int e = 0; e < ne; e++)
         {
             std::vector<double> coords(3*ncn);
@@ -1466,7 +1466,7 @@ void element::fullsplit(int n, std::vector<std::vector<double>>& splitcoords, st
             {
                 std::vector<double> cursplit = calculatecoordinates(curvedtetsubcoords[i], coords);
 
-                for (int j = 0; j < cursplit.size(); j++)
+                for (size_t j = 0; j < cursplit.size(); j++)
                     splitcoords[4][index+j] = cursplit[j];
                 index += cursplit.size();
             }
@@ -1714,7 +1714,7 @@ std::vector<std::vector<int>> element::splittetrahedron(int splitnum, std::vecto
     std::vector<std::vector<bool>> connectivitythroughedge(edgefacingpair.size());
     
     // Add connection:
-    for (int i = 0; i < edgefacingpair.size(); i++)
+    for (size_t i = 0; i < edgefacingpair.size(); i++)
     {
         connectivitythroughedge[i] = connectivity;
     
@@ -1728,7 +1728,7 @@ std::vector<std::vector<int>> element::splittetrahedron(int splitnum, std::vecto
     // Connect the tets:
     std::vector<std::vector<bool>> tetdefs;
     deducetets(connectivity, tetdefs);
-    int numtets = tetdefs.size();
+    size_t numtets = tetdefs.size();
     
     std::vector<int> minnumtet = {1,2,3,4,5,7,8};
     // If a through-edge must be inserted:
@@ -1743,22 +1743,22 @@ std::vector<std::vector<int>> element::splittetrahedron(int splitnum, std::vecto
     // Convert the boolean tetrahedra definition to node numbers:
     std::vector<std::vector<int>> output(8, std::vector<int>(0));
     output[4] = std::vector<int>(numtets*4);
-    for (int i = 0; i < numtets; i++)
+    for (size_t i = 0; i < numtets; i++)
     {
-        int index = 0;
+        size_t index = 0;
         for (int j = 0; j < 10; j++)
         {
             if (tetdefs[i][j])
             {
                 output[4][4*i+index] = j;
-                index++;   
+                index++;
             }
         }
     }
     
     // Reorder the tetrahedra nodes if needed:
     std::vector<double> rc = {0,0,0, 1,0,0, 0,1,0, 0,0,1, 0.5,0,0, 0.5,0.5,0, 0,0.5,0, 0,0,0.5, 0,0.5,0.5, 0.5,0,0.5};
-    for (int i = 0; i < numtets; i++)
+    for (size_t i = 0; i < numtets; i++)
     {
         int p0 = output[4][4*i+0];
         int p1 = output[4][4*i+1];
@@ -1791,7 +1791,7 @@ void element::getsplitconnectivity(std::vector<bool>& connectivity, std::vector<
 {
     connectivity = std::vector<bool>(6*6, false);
 
-    for (int j = 0; j < splitdefinition[2].size()/3; j++)
+    for (size_t j = 0; j < splitdefinition[2].size()/3; j++)
     {
         for (int n = 0; n < 3; n++)
         {
@@ -1812,7 +1812,7 @@ void element::getsplitconnectivity(std::vector<bool>& volumeconnectivity, std::v
     std::vector<int> fnd = getfacesdefinitionsbasedonnodes();
     std::vector<int> fed = getfacesdefinitionsbasedonedges();
     // Face edge definition is provided in a special format:
-    for (int i = 0; i < fed.size(); i++)
+    for (size_t i = 0; i < fed.size(); i++)
         fed[i] = std::abs(fed[i])-1;                                        
     
     // Loop on each face:
@@ -1940,7 +1940,7 @@ void element::numstorefcoords(std::vector<int>& nums, std::vector<double>& refco
         }
     }
         
-    for (int i = 0; i < nums.size(); i++)
+    for (size_t i = 0; i < nums.size(); i++)
     {
         refcoords[3*i+0] = refs[3*nums[i]+0];
         refcoords[3*i+1] = refs[3*nums[i]+1];

--- a/src/expression/operation/mathop.cpp
+++ b/src/expression/operation/mathop.cpp
@@ -54,7 +54,7 @@ bool mathop::isregionempty(int physreg)
 
     std::vector<bool> defin = universe::mymesh->getphysicalregions()->get(physreg)->getdefinition();
     
-    for (int i = 0; i < defin.size(); i++)
+    for (size_t i = 0; i < defin.size(); i++)
     {
         if (defin[i] == true)
             return false;
@@ -71,7 +71,7 @@ bool mathop::isregioninside(int physregtocheck, int physreg)
     std::vector<bool> defin = universe::mymesh->getphysicalregions()->get(physreg)->getdefinition();
     
     // All disjoint regions must be included:
-    for (int i = 0; i < tocheckdefin.size(); i++)
+    for (size_t i = 0; i < tocheckdefin.size(); i++)
     {
         if (tocheckdefin[i] == true && defin[i] == false)
             return false;
@@ -88,7 +88,7 @@ bool mathop::isregiontouching(int physregtocheck, int physreg)
     std::vector<bool> defin = universe::mymesh->getphysicalregions()->get(physreg)->getdefinition();
     
     // At least one disjoint region must be included:
-    for (int i = 0; i < tocheckdefin.size(); i++)
+    for (size_t i = 0; i < tocheckdefin.size(); i++)
     {
         if (tocheckdefin[i] == true && defin[i] == true)
             return true;
@@ -100,7 +100,7 @@ bool mathop::isregiontouching(int physregtocheck, int physreg)
 void mathop::printvector(std::vector<double> input)
 {
     std::cout << "Vector size is " << input.size() << std::endl;
-    for (int i = 0; i < input.size(); i++)
+    for (size_t i = 0; i < input.size(); i++)
         std::cout << input[i] << " ";
     std::cout << std::endl;
 }
@@ -108,7 +108,7 @@ void mathop::printvector(std::vector<double> input)
 void mathop::printvector(std::vector<int> input)
 {
     std::cout << "Vector size is " << input.size() << std::endl;
-    for (int i = 0; i < input.size(); i++)
+    for (size_t i = 0; i < input.size(); i++)
         std::cout << input[i] << " ";
     std::cout << std::endl;
 }
@@ -116,7 +116,7 @@ void mathop::printvector(std::vector<int> input)
 void mathop::printvector(std::vector<bool> input)
 {
     std::cout << "Vector size is " << input.size() << std::endl;
-    for (int i = 0; i < input.size(); i++)
+    for (size_t i = 0; i < input.size(); i++)
         std::cout << input[i] << " ";
     std::cout << std::endl;
 }
@@ -382,7 +382,7 @@ expression mathop::makeharmonic(std::vector<int> harms, std::vector<expression> 
     std::vector<int> alldisjregs(universe::mymesh->getdisjointregions()->count());
     std::iota(alldisjregs.begin(), alldisjregs.end(), 0);
     
-    for (int i = 0; i < harms.size(); i++)
+    for (size_t i = 0; i < harms.size(); i++)
     {
         if (harms[i] <= 0)
         {
@@ -410,7 +410,7 @@ expression mathop::makeharmonic(std::vector<int> harms, std::vector<expression> 
         for (int j = 0; j < n; j++)
         {
             std::vector<std::shared_ptr<operation>> ops(harms.size());
-            for (int k = 0; k < harms.size(); k++)
+            for (size_t k = 0; k < harms.size(); k++)
                 ops[k] = moveharmonic({1},{harms[k]}, exprs[k].at(i,j)).getoperationinarray(0,0);
             std::shared_ptr<opsum> op(new opsum(ops));
             outexprs[i*n+j] = expression(op);
@@ -432,7 +432,7 @@ expression mathop::moveharmonic(std::vector<int> origharms, std::vector<int> des
         std::cout << "Error in 'mathop' namespace: in 'moveharmonic' the number of origin and destination harmonics do not match" << std::endl;
         abort();
     }
-    for (int i = 0; i < origharms.size(); i++)
+    for (size_t i = 0; i < origharms.size(); i++)
     {
         if (origharms[i] <= 0 || destharms[i] <= 0)
         {
@@ -534,7 +534,7 @@ std::vector<double> mathop::printtotalforce(int physreg, expression* meshdeform,
     std::cout << "Total force on region " << physreg << " is ";
     std::vector<std::string> compstr = {"x","y","z"};
 
-    for (int c = 0; c < totforce.size(); c++)
+    for (size_t c = 0; c < totforce.size(); c++)
     {
         std::cout << "f" << compstr[c] << " = " << totforce[c];
         if (c != totforce.size()-1)
@@ -675,10 +675,10 @@ std::vector<std::vector<shape>> mathop::loadshape(std::string meshfile)
     }
     
     std::vector<int> physregnums = loadedphysregs->getallnumbers();
-    int numphysregs = physregnums.size();
+    size_t numphysregs = physregnums.size();
         
     std::vector<std::vector<shape>> output(4,std::vector<shape>(0));
-    for (int i = 0; i < numphysregs; i++)
+    for (size_t i = 0; i < numphysregs; i++)
     {
         int curphysreg = physregnums[i];
         physicalregion* pr = loadedphysregs->get(curphysreg);
@@ -691,11 +691,11 @@ std::vector<std::vector<shape>> mathop::loadshape(std::string meshfile)
         std::vector<std::vector<int>> nodesinelements(8);
         for (int j = 0; j < 8; j++)
         {
-            int numelems = curelemlist->at(j).size();
+            size_t numelems = curelemlist->at(j).size();
             element myelem(j,curvatureorder);
             int numnodes = myelem.countcurvednodes();
             nodesinelements[j].resize(numnodes*numelems);
-            for (int k = 0; k < numelems; k++)
+            for (size_t k = 0; k < numelems; k++)
             {
                 int curelem = curelemlist->at(j)[k];
                 for (int l = 0; l < numnodes; l++)
@@ -707,7 +707,7 @@ std::vector<std::vector<shape>> mathop::loadshape(std::string meshfile)
         int nodeindex = 0;
         for (int j = 0; j < 8; j++)
         {
-            for (int k = 0; k < nodesinelements[j].size(); k++)
+            for (size_t k = 0; k < nodesinelements[j].size(); k++)
             {
                 int curnode = nodesinelements[j][k];
                 if (renumbernodes[curnode] == -1)
@@ -720,7 +720,7 @@ std::vector<std::vector<shape>> mathop::loadshape(std::string meshfile)
         }
         // Create the vector of node coordinates:
         std::vector<double> nodecoordinates(3*nodeindex);
-        for (int j = 0; j < renumbernodes.size(); j++)
+        for (size_t j = 0; j < renumbernodes.size(); j++)
         {
             if (renumbernodes[j] != -1)
             {
@@ -1373,7 +1373,7 @@ std::vector<vec> mathop::solve(mat A, std::vector<vec> b, std::string soltype)
         std::cout << "Error in 'mathop' namespace: unknown direct solver type '" << soltype << "' (use 'lu')" << std::endl;
         abort();
     }
-    for (int i = 0; i < b.size(); i++)
+    for (size_t i = 0; i < b.size(); i++)
     {
         if (A.countrows() != b[i].size())
         {
@@ -1588,7 +1588,7 @@ void mathop::solve(formulation formul)
 
 void mathop::solve(std::vector<formulation> formuls)
 {
-    for (int i = 0; i < formuls.size(); i++)
+    for (size_t i = 0; i < formuls.size(); i++)
         solve(formuls[i]);
 }
 
@@ -1651,7 +1651,7 @@ void mathop::setdata(vec invec)
     // Get all fields in the vec structure:
     std::vector<std::shared_ptr<rawfield>> allfields = invec.getpointer()->getdofmanager()->getfields();
     
-    for (int i = 0; i < allfields.size(); i++)
+    for (size_t i = 0; i < allfields.size(); i++)
         allfields[i]->setdata(-1, invec|field(allfields[i]));
 }
 
@@ -2268,7 +2268,7 @@ expression mathop::predefinedelectrostaticforce(std::vector<expression> dxyztfu,
     epsilon.reuseit();
 
     std::vector<std::vector<expression>> exprs(dxyztfu.size());
-    for (int i = 0; i < dxyztfu.size(); i++)
+    for (size_t i = 0; i < dxyztfu.size(); i++)
         exprs[i] = {dxyztfu[i]};
 
     // Scalar gradient here:

--- a/src/expression/operation/mathop.h
+++ b/src/expression/operation/mathop.h
@@ -295,6 +295,6 @@ namespace mathop
     
     // Stabilization for advection-diffusion problems:
     expression predefinedstabilization(std::string stabtype, expression delta, expression f, expression v, expression diffusivity, expression residual);
-};
+}
 
 #endif

--- a/src/expression/operation/opabs.cpp
+++ b/src/expression/operation/opabs.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<operation> opabs::copy(void)
 std::vector<double> opabs::evaluate(std::vector<double>& xcoords, std::vector<double>& ycoords, std::vector<double>& zcoords)
 {
     std::vector<double> evaluated = myarg->evaluate(xcoords, ycoords, zcoords);
-    for (int i = 0; i < evaluated.size(); i++)
+    for (size_t i = 0; i < evaluated.size(); i++)
         evaluated[i] = std::abs(evaluated[i]);
     return evaluated;
 }

--- a/src/expression/operation/opacos.cpp
+++ b/src/expression/operation/opacos.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<operation> opacos::copy(void)
 std::vector<double> opacos::evaluate(std::vector<double>& xcoords, std::vector<double>& ycoords, std::vector<double>& zcoords)
 {
     std::vector<double> evaluated = myarg->evaluate(xcoords, ycoords, zcoords);
-    for (int i = 0; i < evaluated.size(); i++)
+    for (size_t i = 0; i < evaluated.size(); i++)
         evaluated[i] = std::acos(evaluated[i]);
     return evaluated;
 }

--- a/src/expression/operation/opasin.cpp
+++ b/src/expression/operation/opasin.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<operation> opasin::copy(void)
 std::vector<double> opasin::evaluate(std::vector<double>& xcoords, std::vector<double>& ycoords, std::vector<double>& zcoords)
 {
     std::vector<double> evaluated = myarg->evaluate(xcoords, ycoords, zcoords);
-    for (int i = 0; i < evaluated.size(); i++)
+    for (size_t i = 0; i < evaluated.size(); i++)
         evaluated[i] = std::asin(evaluated[i]);
     return evaluated;
 }

--- a/src/expression/operation/opatan.cpp
+++ b/src/expression/operation/opatan.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<operation> opatan::copy(void)
 std::vector<double> opatan::evaluate(std::vector<double>& xcoords, std::vector<double>& ycoords, std::vector<double>& zcoords)
 {
     std::vector<double> evaluated = myarg->evaluate(xcoords, ycoords, zcoords);
-    for (int i = 0; i < evaluated.size(); i++)
+    for (size_t i = 0; i < evaluated.size(); i++)
         evaluated[i] = std::atan(evaluated[i]);
     return evaluated;
 }

--- a/src/expression/operation/opathp.cpp
+++ b/src/expression/operation/opathp.cpp
@@ -56,7 +56,7 @@ std::vector<std::vector<densematrix>> opathp::interpolate(elementselector& elems
         (universe::mymesh->gethtracker())->getattarget(ads, rcs, myrawmesh->gethtracker().get(), tel, trc);
         
         // Recombine:
-        for (int i = 0; i < elemnumshere.size()/2; i++)
+        for (size_t i = 0; i < elemnumshere.size()/2; i++)
         {
             int typ = elemnumshere[2*i+0];
             int ind = indexinrcsoforigin[i];
@@ -80,7 +80,7 @@ std::vector<std::vector<densematrix>> opathp::interpolate(elementselector& elems
         std::vector<std::vector<int>> hererenumbering;
         (myrawmesh->getptracker())->getrenumbering(myptracker, hererenumbering);
 
-        for (int i = 0; i < elemnumshere.size()/2; i++)
+        for (size_t i = 0; i < elemnumshere.size()/2; i++)
             elemnumshere[2*i+1] = hererenumbering[elemnumshere[2*i+0]][elemnumshere[2*i+1]];
     }
 
@@ -127,7 +127,7 @@ std::vector<std::vector<densematrix>> opathp::interpolate(elementselector& elems
                       
                 // Place the interpolated values at the right position in the output densematrix:
                 std::vector<int> originds = myselector.getoriginalindexes();
-                for (int j = 0; j < originds.size(); j++)
+                for (size_t j = 0; j < originds.size(); j++)
                 {
                     int curorigelem = originds[j];
                     for (int k = 0; k < numrefcoords; k++)

--- a/src/expression/operation/opcondition.cpp
+++ b/src/expression/operation/opcondition.cpp
@@ -99,7 +99,7 @@ std::vector<double> opcondition::evaluate(std::vector<double>& xcoords, std::vec
     std::vector<double> evaldtrue = mytrue->evaluate(xcoords, ycoords, zcoords);
     std::vector<double> evaldfalse = myfalse->evaluate(xcoords, ycoords, zcoords);
 
-    for (int i = 0; i < evaldcond.size(); i++)
+    for (size_t i = 0; i < evaldcond.size(); i++)
     {
         if (evaldcond[i] < 0)
             evaldtrue[i] = evaldfalse[i];

--- a/src/expression/operation/opcos.cpp
+++ b/src/expression/operation/opcos.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<operation> opcos::copy(void)
 std::vector<double> opcos::evaluate(std::vector<double>& xcoords, std::vector<double>& ycoords, std::vector<double>& zcoords)
 {
     std::vector<double> evaluated = myarg->evaluate(xcoords, ycoords, zcoords);
-    for (int i = 0; i < evaluated.size(); i++)
+    for (size_t i = 0; i < evaluated.size(); i++)
         evaluated[i] = std::cos(evaluated[i]);
     return evaluated;
 }

--- a/src/expression/operation/opinversion.cpp
+++ b/src/expression/operation/opinversion.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<operation> opinversion::copy(void)
 std::vector<double> opinversion::evaluate(std::vector<double>& xcoords, std::vector<double>& ycoords, std::vector<double>& zcoords)
 {
     std::vector<double> evaluated = myarg->evaluate(xcoords, ycoords, zcoords);
-    for (int i = 0; i < evaluated.size(); i++)
+    for (size_t i = 0; i < evaluated.size(); i++)
         evaluated[i] = 1.0/evaluated[i];
     return evaluated;
 }

--- a/src/expression/operation/oplog10.cpp
+++ b/src/expression/operation/oplog10.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<operation> oplog10::copy(void)
 std::vector<double> oplog10::evaluate(std::vector<double>& xcoords, std::vector<double>& ycoords, std::vector<double>& zcoords)
 {
     std::vector<double> evaluated = myarg->evaluate(xcoords, ycoords, zcoords);
-    for (int i = 0; i < evaluated.size(); i++)
+    for (size_t i = 0; i < evaluated.size(); i++)
         evaluated[i] = std::log10(evaluated[i]);
     return evaluated;
 }

--- a/src/expression/operation/opmod.cpp
+++ b/src/expression/operation/opmod.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<operation> opmod::copy(void)
 std::vector<double> opmod::evaluate(std::vector<double>& xcoords, std::vector<double>& ycoords, std::vector<double>& zcoords)
 {
     std::vector<double> evaluated = myarg->evaluate(xcoords, ycoords, zcoords);
-    for (int i = 0; i < evaluated.size(); i++)
+    for (size_t i = 0; i < evaluated.size(); i++)
         evaluated[i] = std::fmod(evaluated[i], mymodval);
     return evaluated;
 }

--- a/src/expression/operation/opon.cpp
+++ b/src/expression/operation/opon.cpp
@@ -82,7 +82,7 @@ std::vector<std::vector<densematrix>> opon::interpolate(elementselector& elemsel
     
     if (myerrorifnotfound)
     {
-        for (int i = 0; i < isfound.size(); i++)
+        for (size_t i = 0; i < isfound.size(); i++)
         {
             if (isfound[i] == false)
             {
@@ -96,7 +96,7 @@ std::vector<std::vector<densematrix>> opon::interpolate(elementselector& elemsel
     
     // Place the interpolated values in a std::vector<std::vector<densematrix>>:
     std::vector<std::vector<densematrix>> outvec(interpolated.size(), std::vector<densematrix>(0));
-    for (int h = 0; h < interpolated.size(); h++)
+    for (size_t h = 0; h < interpolated.size(); h++)
     {
         if (interpolated[h].size() > 0)
         {
@@ -190,7 +190,7 @@ densematrix opon::multiharmonicinterpolate(int numtimeevals, elementselector& el
 
     if (myerrorifnotfound)
     {
-        for (int i = 0; i < isfound.size(); i++)
+        for (size_t i = 0; i < isfound.size(); i++)
         {
             if (isfound[i] == false)
             {

--- a/src/expression/operation/opparameter.cpp
+++ b/src/expression/operation/opparameter.cpp
@@ -35,7 +35,7 @@ densematrix opparameter::multiharmonicinterpolate(int numtimeevals, elementselec
 
 bool opparameter::isharmonicone(std::vector<int> disjregs) 
 { 
-    for (int i = 0; i < disjregs.size(); i++)
+    for (size_t i = 0; i < disjregs.size(); i++)
     {
         if ( (myparameter->get(disjregs[i], myrow, mycolumn))->isharmonicone({disjregs[i]}) == false )
             return false;
@@ -45,14 +45,14 @@ bool opparameter::isharmonicone(std::vector<int> disjregs)
 
 std::shared_ptr<operation> opparameter::simplify(std::vector<int> disjregs)
 {
-    for (int i = 0; i < disjregs.size(); i++)
+    for (size_t i = 0; i < disjregs.size(); i++)
         myparameter->simplify(myrow, mycolumn, disjregs[i]);
     return shared_from_this();
 }
 
 bool opparameter::isvalueorientationdependent(std::vector<int> disjregs)
 {
-    for (int i = 0; i < disjregs.size(); i++)
+    for (size_t i = 0; i < disjregs.size(); i++)
     {
         if ( (myparameter->get(disjregs[i], myrow, mycolumn))->isvalueorientationdependent({disjregs[i]}) == true )
             return true;

--- a/src/expression/operation/oppower.cpp
+++ b/src/expression/operation/oppower.cpp
@@ -71,7 +71,7 @@ std::vector<double> oppower::evaluate(std::vector<double>& xcoords, std::vector<
     std::vector<double> evaluatedbase = mybase->evaluate(xcoords, ycoords, zcoords);
     std::vector<double> evaluatedexponent = myexponent->evaluate(xcoords, ycoords, zcoords);
 
-    for (int i = 0; i < xcoords.size(); i++)
+    for (size_t i = 0; i < xcoords.size(); i++)
         evaluatedbase[i] = std::pow(evaluatedbase[i], evaluatedexponent[i]);
     return evaluatedbase;
 }

--- a/src/expression/operation/opsin.cpp
+++ b/src/expression/operation/opsin.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<operation> opsin::copy(void)
 std::vector<double> opsin::evaluate(std::vector<double>& xcoords, std::vector<double>& ycoords, std::vector<double>& zcoords)
 {
     std::vector<double> evaluated = myarg->evaluate(xcoords, ycoords, zcoords);
-    for (int i = 0; i < evaluated.size(); i++)
+    for (size_t i = 0; i < evaluated.size(); i++)
         evaluated[i] = std::sin(evaluated[i]);
     return evaluated;
 }

--- a/src/expression/operation/opsum.cpp
+++ b/src/expression/operation/opsum.cpp
@@ -24,7 +24,7 @@ std::vector<std::vector<densematrix>> opsum::interpolate(elementselector& elemse
     // Compute first all the sum terms and get the max number of harmonics.
     int maxnumberofharmonics = 0;
     std::vector< std::vector<std::vector<densematrix>> > computedterms(sumterms.size());
-    for (int i = 0; i < sumterms.size(); i++)
+    for (size_t i = 0; i < sumterms.size(); i++)
     {
         computedterms[i] = sumterms[i]->interpolate(elemselect, evaluationcoordinates, meshdeform);
         if (computedterms[i].size() > maxnumberofharmonics)
@@ -37,7 +37,7 @@ std::vector<std::vector<densematrix>> opsum::interpolate(elementselector& elemse
     // Sum all harmonics together (ignore harmonic sin0):
     for (int harm = 1; harm < maxnumberofharmonics; harm++)
     {
-        for (int i = 0; i < sumterms.size(); i++)
+        for (size_t i = 0; i < sumterms.size(); i++)
         {
             // If the sum term exists for the current harmonic:
             if (harm < computedterms[i].size() && computedterms[i][harm].size() == 1)
@@ -68,7 +68,7 @@ densematrix opsum::multiharmonicinterpolate(int numtimeevals, elementselector& e
     
     densematrix output = sumterms[0]->multiharmonicinterpolate(numtimeevals, elemselect, evaluationcoordinates, meshdeform);
     
-    for (int i = 1; i < sumterms.size(); i++)
+    for (size_t i = 1; i < sumterms.size(); i++)
         output.add(sumterms[i]->multiharmonicinterpolate(numtimeevals, elemselect, evaluationcoordinates, meshdeform));
     
     if (reuse && universe::isreuseallowed)
@@ -79,7 +79,7 @@ densematrix opsum::multiharmonicinterpolate(int numtimeevals, elementselector& e
 
 std::shared_ptr<operation> opsum::expand(void)
 {
-    for (int i = 0; i < sumterms.size(); i++)
+    for (size_t i = 0; i < sumterms.size(); i++)
     {
         // We only want to expand operations that include a dof() or tf().
         if (sumterms[i]->isdofincluded() || sumterms[i]->istfincluded())
@@ -95,7 +95,7 @@ void opsum::group(void)
 {
     std::vector<std::shared_ptr<operation>> groupedsumterms = {};
     
-    for (int i = 0; i < sumterms.size(); i++)
+    for (size_t i = 0; i < sumterms.size(); i++)
     {
         sumterms[i]->group();
 
@@ -155,10 +155,10 @@ std::shared_ptr<operation> opsum::copy(void)
 std::vector<double> opsum::evaluate(std::vector<double>& xcoords, std::vector<double>& ycoords, std::vector<double>& zcoords)
 {
     std::vector<double> evaluated(xcoords.size(), 0);
-    for (int i = 0; i < sumterms.size(); i++)
+    for (size_t i = 0; i < sumterms.size(); i++)
     {
         std::vector<double> current = sumterms[i]->evaluate(xcoords, ycoords, zcoords);
-        for (int j = 0; j < xcoords.size(); j++)
+        for (size_t j = 0; j < xcoords.size(); j++)
             evaluated[j] += current[j];
     }
     return evaluated;
@@ -167,7 +167,7 @@ std::vector<double> opsum::evaluate(std::vector<double>& xcoords, std::vector<do
 void opsum::print(void)
 {
     std::cout << "(";
-    for (int i = 0; i < sumterms.size(); i++)
+    for (size_t i = 0; i < sumterms.size(); i++)
     {
         if (i > 0)
             std::cout << " + ";

--- a/src/expression/operation/optan.cpp
+++ b/src/expression/operation/optan.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<operation> optan::copy(void)
 std::vector<double> optan::evaluate(std::vector<double>& xcoords, std::vector<double>& ycoords, std::vector<double>& zcoords)
 {
     std::vector<double> evaluated = myarg->evaluate(xcoords, ycoords, zcoords);
-    for (int i = 0; i < evaluated.size(); i++)
+    for (size_t i = 0; i < evaluated.size(); i++)
         evaluated[i] = std::tan(evaluated[i]);
     return evaluated;
 }

--- a/src/expression/rawparameter.cpp
+++ b/src/expression/rawparameter.cpp
@@ -16,7 +16,7 @@ void rawparameter::synchronize(void)
     opnums = std::vector<int>(universe::mymesh->getdisjointregions()->count(),-1);
 
     // Rebuild the structure:
-    for (int i = 0; i < mystructuretracker.size(); i++)
+    for (size_t i = 0; i < mystructuretracker.size(); i++)
         set(mystructuretracker[i].first, mystructuretracker[i].second);
     
     
@@ -28,7 +28,7 @@ void rawparameter::errorifundefined(std::vector<int> disjregs)
 {
     synchronize();
 
-    for (int i = 0; i < disjregs.size(); i++)
+    for (size_t i = 0; i < disjregs.size(); i++)
     {
         if (myoperations[disjregs[i]].size() == 1 && myoperations[disjregs[i]][0] == NULL)
         {
@@ -43,7 +43,7 @@ std::vector<int> rawparameter::getopnums(std::vector<int> disjregs)
     synchronize();
     
     std::vector<int> output(disjregs.size());
-    for (int i = 0; i < disjregs.size(); i++)
+    for (size_t i = 0; i < disjregs.size(); i++)
         output[i] = opnums[disjregs[i]];
     return output;
 }
@@ -75,7 +75,7 @@ void rawparameter::set(int physreg, expression input)
     // Consider ALL disjoint regions in the physical region with (-1):
     std::vector<int> selecteddisjregs = ((universe::mymesh->getphysicalregions())->get(physreg))->getdisjointregions(-1);
 
-    for (int i = 0; i < selecteddisjregs.size(); i++)
+    for (size_t i = 0; i < selecteddisjregs.size(); i++)
     {
         opnums[selecteddisjregs[i]] = maxopnum;
         for (int row = 0; row < mynumrows; row++)
@@ -150,14 +150,14 @@ std::vector<std::vector<densematrix>> rawparameter::interpolate(int row, int col
         // Preallocate the harmonics not yet in 'out':
         if (out.size() < currentinterp.size())
             out.resize(currentinterp.size());
-        for (int h = 0; h < currentinterp.size(); h++)
+        for (size_t h = 0; h < currentinterp.size(); h++)
         {
             if (currentinterp[h].size() == 1 && out[h].size() == 0)
                 out[h] = {densematrix(elemselect.countincurrentorientation(), evaluationcoordinates.size()/3, 0)};
         }
         
         // Insert 'currentinterp' in 'out':
-        for (int h = 0; h < currentinterp.size(); h++)
+        for (size_t h = 0; h < currentinterp.size(); h++)
         {
             if (currentinterp[h].size() == 1)
                 out[h][0].insertatrows(elemselect.getelementindexes(), currentinterp[h][0]);
@@ -206,9 +206,9 @@ densematrix rawparameter::multiharmonicinterpolate(int row, int col, int numtime
         
         std::vector<int> selectedelementindexes = elemselect.getelementindexes();
         std::vector<int> selectedcolumns(selectedelementindexes.size()*evaluationcoordinates.size()/3);
-        for (int j = 0; j < selectedelementindexes.size(); j++)
+        for (size_t j = 0; j < selectedelementindexes.size(); j++)
         {
-            for (int k = 0; k < evaluationcoordinates.size()/3; k++)
+            for (size_t k = 0; k < evaluationcoordinates.size()/3; k++)
                 selectedcolumns[j*evaluationcoordinates.size()/3+k] = selectedelementindexes[j]*evaluationcoordinates.size()/3+k;
         }
         out.insertatcolumns(selectedcolumns, myoperations[mydisjregs[0]][row*mynumcols+col]->multiharmonicinterpolate(numtimeevals, myselection, evaluationcoordinates, meshdeform));
@@ -239,7 +239,7 @@ void rawparameter::print(void)
     std::cout << std::endl;
     std::cout << "Printing parameter of size " << mynumrows << "x" << mynumcols;
     std::cout << std::endl;
-    for (int i = 0; i < myoperations.size(); i++)
+    for (size_t i = 0; i < myoperations.size(); i++)
     {   
         if (myoperations[i][0] != NULL)
         {

--- a/src/field/coefmanager.cpp
+++ b/src/field/coefmanager.cpp
@@ -14,7 +14,7 @@ coefmanager::coefmanager(std::string fieldtypename, disjointregions* drs)
     // Preallocate 'coefs' for the number of disjoint regions:
     coefs.resize(mydisjointregions.count());
     // Resize coefs to accomodate an inital order 1 interpolated field:
-    for (int i = 0; i < coefs.size(); i++)
+    for (size_t i = 0; i < coefs.size(); i++)
         fitinterpolationorder(i, 1);
 }
 
@@ -68,9 +68,9 @@ void coefmanager::print(bool databoundsonly)
 {
     std::cout << std::endl << "Field of type " << myfieldtypename << ":" << std::endl;
     
-    for (int d = 0; d < coefs.size(); d++)
+    for (size_t d = 0; d < coefs.size(); d++)
     {
-        for (int ff = 0; ff < coefs[d].size(); ff++)
+        for (size_t ff = 0; ff < coefs[d].size(); ff++)
         {
             if (coefs[d][ff].size() == 0)
                 continue;
@@ -80,7 +80,7 @@ void coefmanager::print(bool databoundsonly)
             double datamin = coefs[d][ff][0];
             double datamax = coefs[d][ff][0];
             
-            for (int e = 0; e < coefs[d][ff].size(); e++)
+            for (size_t e = 0; e < coefs[d][ff].size(); e++)
             {
                 double val = coefs[d][ff][e];
                 

--- a/src/field/field.cpp
+++ b/src/field/field.cpp
@@ -14,7 +14,7 @@ field::field(std::string fieldtypename) { rawfieldptr = std::shared_ptr<rawfield
 field::field(std::string fieldtypename, const std::vector<int> harmonicnumbers) 
 { 
     // Make sure all harmonic numbers are positive and non zero:
-    for (int i = 0; i < harmonicnumbers.size(); i++)
+    for (size_t i = 0; i < harmonicnumbers.size(); i++)
     {
         if (harmonicnumbers[i] <= 0)
         {
@@ -39,7 +39,7 @@ field::field(std::string fieldtypename, spanningtree spantree)
 field::field(std::string fieldtypename, const std::vector<int> harmonicnumbers, spanningtree spantree)
 {
     // Make sure all harmonic numbers are positive and non zero:
-    for (int i = 0; i < harmonicnumbers.size(); i++)
+    for (size_t i = 0; i < harmonicnumbers.size(); i++)
     {
         if (harmonicnumbers[i] <= 0)
         {
@@ -325,7 +325,7 @@ field field::harmonic(const std::vector<int> harmonicnumbers)
         abort();
     }    
     // Make sure all harmonic numbers are positive and non zero:
-    for (int i = 0; i < harmonicnumbers.size(); i++)
+    for (size_t i = 0; i < harmonicnumbers.size(); i++)
     {
         if (harmonicnumbers[i] <= 0)
         {

--- a/src/field/rawfield.cpp
+++ b/src/field/rawfield.cpp
@@ -10,9 +10,9 @@ void rawfield::synchronize(std::vector<int> physregsfororder, std::vector<int> d
     // Synchronize all subfields and harmonics:
     if (mysubfields.size() != 0 || myharmonics.size() != 0)
     {
-        for (int i = 0; i < mysubfields.size(); i++)
+        for (size_t i = 0; i < mysubfields.size(); i++)
             mysubfields[i][0]->synchronize();
-        for (int h = 0; h < myharmonics.size(); h++)
+        for (size_t h = 0; h < myharmonics.size(); h++)
         {
             if (myharmonics[h].size() > 0)
                 myharmonics[h][0]->synchronize();
@@ -42,7 +42,7 @@ void rawfield::synchronize(std::vector<int> physregsfororder, std::vector<int> d
     {
         if (physregsfororder.size() == 0)
         {
-            for (int i = 0; i < myordertracker.size(); i++)
+            for (size_t i = 0; i < myordertracker.size(); i++)
                 setorder(myordertracker[i].first, myordertracker[i].second, false);
         }
         else
@@ -55,18 +55,18 @@ void rawfield::synchronize(std::vector<int> physregsfororder, std::vector<int> d
     else
     {
         interpolationorder = disjregsfororder;
-        for (int i = 0; i < interpolationorder.size(); i++)
+        for (size_t i = 0; i < interpolationorder.size(); i++)
             mycoefmanager->fitinterpolationorder(i, interpolationorder[i]); 
     }
-    for (int i = 0; i < myconstraintphysregtracker.size(); i++)
+    for (size_t i = 0; i < myconstraintphysregtracker.size(); i++)
     {
         std::vector<int> selecteddisjregs = ((universe::mymesh->getphysicalregions())->get(myconstraintphysregtracker[i]))->getdisjointregions(-1);
-        for (int j = 0; j < selecteddisjregs.size(); j++)
+        for (size_t j = 0; j < selecteddisjregs.size(); j++)
             myconstraints[selecteddisjregs[j]] = myconstraintcalctracker[i];
     }
-    for (int i = 0; i < myconditionalconstrainttracker.size(); i++)
+    for (size_t i = 0; i < myconditionalconstrainttracker.size(); i++)
         setconditionalconstraint(std::get<0>(myconditionalconstrainttracker[i]), std::get<1>(myconditionalconstrainttracker[i]), std::get<2>(myconditionalconstrainttracker[i]));
-    for (int i = 0; i < mygaugetracker.size(); i++)
+    for (size_t i = 0; i < mygaugetracker.size(); i++)
         setgauge(mygaugetracker[i]);
         
     // Update the coef manager with the new nodal/edge/face/volume shape function coefficients:
@@ -184,7 +184,7 @@ void rawfield::updateothershapefunctions(std::shared_ptr<rawfield> originalthis,
     std::vector<int> alldrsindim = drs->getindim(dim);
     // Count the number of non-empty diagonal blocks:
     int numblocks = 0, preallocsize = 0;
-    for (int d = 0; d < alldrsindim.size(); d++)
+    for (size_t d = 0; d < alldrsindim.size(); d++)
     {
         int curdr = alldrsindim[d];
         int numelemsindr = drs->countelements(curdr);
@@ -204,7 +204,7 @@ void rawfield::updateothershapefunctions(std::shared_ptr<rawfield> originalthis,
         intdensematrix renumtodiagblocks(dm->countdofs(), 1);
         int* renumptr = renumtodiagblocks.getvalues();
         int index = 0;
-        for (int d = 0; d < alldrsindim.size(); d++)
+        for (size_t d = 0; d < alldrsindim.size(); d++)
         {
             int curdr = alldrsindim[d];
             int numelemsindr = drs->countelements(curdr);
@@ -268,9 +268,9 @@ void rawfield::updateothershapefunctions(std::shared_ptr<rawfield> originalthis,
 
 void rawfield::allowsynchronizing(bool allowit)
 {
-    for (int i = 0; i < mysubfields.size(); i++)
+    for (size_t i = 0; i < mysubfields.size(); i++)
         mysubfields[i][0]->allowsynchronizing(allowit);
-    for (int i = 0; i < myharmonics.size(); i++)
+    for (size_t i = 0; i < myharmonics.size(); i++)
     {
         if (myharmonics[i].size() > 0)
             myharmonics[i][0]->allowsynchronizing(allowit);
@@ -281,9 +281,9 @@ void rawfield::allowsynchronizing(bool allowit)
 
 void rawfield::allowvaluesynchronizing(bool allowit)
 {
-    for (int i = 0; i < mysubfields.size(); i++)
+    for (size_t i = 0; i < mysubfields.size(); i++)
         mysubfields[i][0]->allowvaluesynchronizing(allowit);
-    for (int i = 0; i < myharmonics.size(); i++)
+    for (size_t i = 0; i < myharmonics.size(); i++)
     {
         if (myharmonics[i].size() > 0)
             myharmonics[i][0]->allowvaluesynchronizing(allowit);
@@ -294,9 +294,9 @@ void rawfield::allowvaluesynchronizing(bool allowit)
 
 void rawfield::setupdateaccuracy(int extraintegrationorder)
 {
-    for (int i = 0; i < mysubfields.size(); i++)
+    for (size_t i = 0; i < mysubfields.size(); i++)
         mysubfields[i][0]->setupdateaccuracy(extraintegrationorder);
-    for (int i = 0; i < myharmonics.size(); i++)
+    for (size_t i = 0; i < myharmonics.size(); i++)
     {
         if (myharmonics[i].size() > 0)
             myharmonics[i][0]->setupdateaccuracy(extraintegrationorder);
@@ -362,7 +362,7 @@ rawfield::rawfield(std::string fieldtypename, const std::vector<int> harmonicnum
         if (harmonicnumbers.size() != 0)
         {
             myharmonics.resize(*max_element(harmonicnumbers.begin(), harmonicnumbers.end())+1);
-            for (int h = 0; h < harmonicnumbers.size(); h++)
+            for (size_t h = 0; h < harmonicnumbers.size(); h++)
                 myharmonics[harmonicnumbers[h]] = { std::shared_ptr<rawfield>(new rawfield(mytypename, {}, ismultiharm)) };
         }    
         else
@@ -452,7 +452,7 @@ std::vector<int> rawfield::getharmonics(void)
     {
         std::vector<int> harms = {};
 
-        for (int h = 0; h < myharmonics.size(); h++)
+        for (size_t h = 0; h < myharmonics.size(); h++)
         {
             if (myharmonics[h].size() > 0)
                 harms.push_back(h);
@@ -476,7 +476,7 @@ int rawfield::getfirstharmonic(void)
             return 1;
         else
         {
-            for (int h = 0; h < myharmonics.size(); h++)
+            for (size_t h = 0; h < myharmonics.size(); h++)
             {
                 if (myharmonics[h].size() == 1)
                     return h;
@@ -516,7 +516,7 @@ void rawfield::printharmonics(void)
             std::cout << " +vc0*cos(0*pif0t)";
             return;
         }
-        for (int h = 0; h < myharmonics.size(); h++)
+        for (size_t h = 0; h < myharmonics.size(); h++)
         {
             // Make sure the harmonic exists:
             if (myharmonics[h].size() != 0)
@@ -541,7 +541,7 @@ std::shared_ptr<coefmanager> rawfield::resetcoefmanager(void)
     
     mycoefmanager = std::shared_ptr<coefmanager>(new coefmanager(mytypename, myptracker->getdisjointregions()));
     
-    for (int i = 0; i < interpolationorder.size(); i++)
+    for (size_t i = 0; i < interpolationorder.size(); i++)
         mycoefmanager->fitinterpolationorder(i, interpolationorder[i]);
     
     return outcm;
@@ -580,9 +580,9 @@ void rawfield::setname(std::string name)
     
     myname = name;
     
-    for (int i = 0; i < mysubfields.size(); i++)
+    for (size_t i = 0; i < mysubfields.size(); i++)
         mysubfields[i][0]->setname(name);
-    for (int i = 0; i < myharmonics.size(); i++)
+    for (size_t i = 0; i < myharmonics.size(); i++)
     {
         if (myharmonics[i].size() > 0)
             myharmonics[i][0]->setname(name);
@@ -642,9 +642,9 @@ void rawfield::setorder(int physreg, int interpolorder, bool iscalledbyuser)
     }
         
     // Set the interpolation order on the sub fields:
-    for (int i = 0; i < mysubfields.size(); i++)
+    for (size_t i = 0; i < mysubfields.size(); i++)
         mysubfields[i][0]->setorder(physreg, interpolorder, iscalledbyuser);
-    for (int i = 0; i < myharmonics.size(); i++)
+    for (size_t i = 0; i < myharmonics.size(); i++)
     {
         if (myharmonics[i].size() > 0)
             myharmonics[i][0]->setorder(physreg, interpolorder, iscalledbyuser);
@@ -655,7 +655,7 @@ void rawfield::setorder(int physreg, int interpolorder, bool iscalledbyuser)
         // Consider ALL disjoint regions in the physical region with (-1):
         std::vector<int> selecteddisjregs = ((universe::mymesh->getphysicalregions())->get(physreg))->getdisjointregions(-1);
         
-        for (int i = 0; i < selecteddisjregs.size(); i++)
+        for (size_t i = 0; i < selecteddisjregs.size(); i++)
         {
             interpolationorder[selecteddisjregs[i]] = interpolorder;
             mycoefmanager->fitinterpolationorder(selecteddisjregs[i], interpolorder);
@@ -674,9 +674,9 @@ void rawfield::setorder(expression criterion, int loworder, int highorder)
     }
     
     // Set the interpolation order on the sub fields:
-    for (int i = 0; i < mysubfields.size(); i++)
+    for (size_t i = 0; i < mysubfields.size(); i++)
         mysubfields[i][0]->setorder(criterion, loworder, highorder);
-    for (int i = 0; i < myharmonics.size(); i++)
+    for (size_t i = 0; i < myharmonics.size(); i++)
     {
         if (myharmonics[i].size() > 0)
             myharmonics[i][0]->setorder(criterion, loworder, highorder);
@@ -708,7 +708,7 @@ void rawfield::setvalue(int physreg, int numfftharms, expression* meshdeform, ex
     }
     
     // Set the values on the sub fields:
-    for (int i = 0; i < mysubfields.size(); i++)
+    for (size_t i = 0; i < mysubfields.size(); i++)
         mysubfields[i][0]->setvalue(physreg, numfftharms, meshdeform, input.at(i,0), extraintegrationdegree);
 
     if (mysubfields.size() == 0)
@@ -864,7 +864,7 @@ void rawfield::setconstraint(int physreg, int numfftharms, expression* meshdefor
     }
         
     // Set the constraints on the sub fields:
-    for (int i = 0; i < mysubfields.size(); i++)
+    for (size_t i = 0; i < mysubfields.size(); i++)
         mysubfields[i][0]->setconstraint(physreg, numfftharms, meshdeform, input.at(i,0), extraintegrationdegree);
         
     if (mysubfields.size() == 0)
@@ -891,12 +891,12 @@ void rawfield::setconstraint(int physreg, int numfftharms, expression* meshdefor
                 myconstraintcalctracker.push_back(constraintcomputation);
             }
         
-            for (int i = 0; i < selecteddisjregs.size(); i++)
+            for (size_t i = 0; i < selecteddisjregs.size(); i++)
                 myconstraints[selecteddisjregs[i]] = constraintcomputation;
         }
         else
         {
-            for (int h = 0; h < myharmonics.size(); h++)
+            for (size_t h = 0; h < myharmonics.size(); h++)
             {
                 if (myharmonics[h].size() > 0)
                 {
@@ -906,7 +906,7 @@ void rawfield::setconstraint(int physreg, int numfftharms, expression* meshdefor
                         myharmonics[h][0]->myconstraintcalctracker.push_back(constraintcomputation);
                     }
                 
-                    for (int i = 0; i < selecteddisjregs.size(); i++)
+                    for (size_t i = 0; i < selecteddisjregs.size(); i++)
                         myharmonics[h][0]->myconstraints[selecteddisjregs[i]] = constraintcomputation;
                 }
             }
@@ -957,10 +957,10 @@ void rawfield::setconditionalconstraint(int physreg, expression condexpr, expres
     }
         
     // Set the constraints on the sub fields:
-    for (int i = 0; i < mysubfields.size(); i++)
+    for (size_t i = 0; i < mysubfields.size(); i++)
         mysubfields[i][0]->setconditionalconstraint(physreg, condexpr, valexpr.at(i,0));
     // Set the constraints on the harmonics:
-    for (int i = 0; i < myharmonics.size(); i++)
+    for (size_t i = 0; i < myharmonics.size(); i++)
     {
         if (myharmonics[i].size() > 0)
             myharmonics[i][0]->setconditionalconstraint(physreg, condexpr, valexpr);
@@ -971,7 +971,7 @@ void rawfield::setconditionalconstraint(int physreg, expression condexpr, expres
         // Consider only the NODAL disjoint regions in the physical region with (0):
         std::vector<int> selecteddisjregs = ((universe::mymesh->getphysicalregions())->get(physreg))->getdisjointregions(0);
 
-        for (int i = 0; i < selecteddisjregs.size(); i++)
+        for (size_t i = 0; i < selecteddisjregs.size(); i++)
             myconditionalconstraints[selecteddisjregs[i]] = {condexpr, valexpr};
     }
 }
@@ -985,10 +985,10 @@ void rawfield::setgauge(int physreg)
         mygaugetracker.push_back(physreg);
         
     // Set the gauge on the subfields (if any):
-    for (int i = 0; i < mysubfields.size(); i++)
+    for (size_t i = 0; i < mysubfields.size(); i++)
         mysubfields[i][0]->setgauge(physreg);
     // Set the gauge on the harmonics:
-    for (int i = 0; i < myharmonics.size(); i++)
+    for (size_t i = 0; i < myharmonics.size(); i++)
     {
         if (myharmonics[i].size() > 0)
             myharmonics[i][0]->setgauge(physreg);
@@ -999,7 +999,7 @@ void rawfield::setgauge(int physreg)
         // Get ALL disjoint regions in the physical region (not only ders, to remove grad type form functions).
         std::vector<int> selecteddisjregs = ((universe::mymesh->getphysicalregions())->get(physreg))->getdisjointregions(-1);
 
-        for (int i = 0; i < selecteddisjregs.size(); i++)
+        for (size_t i = 0; i < selecteddisjregs.size(); i++)
             isitgauged[selecteddisjregs[i]] = true;
     }
 }
@@ -1009,10 +1009,10 @@ void rawfield::setspanningtree(spanningtree spantree)
     synchronize();
     
     // Set the spanning tree on the sub fields:
-    for (int i = 0; i < mysubfields.size(); i++)
+    for (size_t i = 0; i < mysubfields.size(); i++)
         mysubfields[i][0]->setspanningtree(spantree);
     // Set the spanning tree on the harmonics:
-    for (int i = 0; i < myharmonics.size(); i++)
+    for (size_t i = 0; i < myharmonics.size(); i++)
     {
         if (myharmonics[i].size() > 0)
             myharmonics[i][0]->setspanningtree(spantree);
@@ -1089,7 +1089,7 @@ void rawfield::setdata(int physreg, vectorfieldselect myvec, std::string op)
     // Get the data of every subfield:
     if (mysubfields.size() > 0)
     {
-        for (int i = 0; i < mysubfields.size(); i++)
+        for (size_t i = 0; i < mysubfields.size(); i++)
             mysubfields[i][0]->setdata(physreg, vectorfieldselect(selectedvec, selectedrawfield->mysubfields[i][0]), op);
     }
     else
@@ -1104,7 +1104,7 @@ void rawfield::setdata(int physreg, vectorfieldselect myvec, std::string op)
         // Get the data of every harmonic:
         if (myharmonics.size() > 0)
         {
-            for (int h = 0; h < myharmonics.size(); h++)
+            for (size_t h = 0; h < myharmonics.size(); h++)
             {
                 if (myharmonics[h].size() > 0)
                     myharmonics[h][0]->setdata(physreg, vectorfieldselect(selectedvec, selectedrawfield->harmonic(h)), op);
@@ -1129,7 +1129,7 @@ void rawfield::setdata(int physreg, vectorfieldselect myvec, std::string op)
                 selecteddisjregs = dofmngr->getdisjointregionsofselectedfield();
             }
 
-            for (int i = 0; i < selecteddisjregs.size(); i++)
+            for (size_t i = 0; i < selecteddisjregs.size(); i++)
             {
                 int disjreg = selecteddisjregs[i];
 
@@ -1200,7 +1200,7 @@ void rawfield::transferdata(int physreg, vectorfieldselect myvec, std::string op
     // Transfer the data of every subfield:
     if (mysubfields.size() > 0)
     {
-        for (int i = 0; i < mysubfields.size(); i++)
+        for (size_t i = 0; i < mysubfields.size(); i++)
             mysubfields[i][0]->transferdata(physreg, vectorfieldselect(selectedvec, selectedrawfield->mysubfields[i][0]), op);
         return;
     }
@@ -1215,7 +1215,7 @@ void rawfield::transferdata(int physreg, vectorfieldselect myvec, std::string op
     // Transfer the data of every harmonic:
     if (myharmonics.size() > 0)
     {
-        for (int h = 0; h < myharmonics.size(); h++)
+        for (size_t h = 0; h < myharmonics.size(); h++)
         {
             if (myharmonics[h].size() > 0)
                 myharmonics[h][0]->transferdata(physreg, vectorfieldselect(selectedvec, selectedrawfield->harmonic(h)), op);
@@ -1239,7 +1239,7 @@ void rawfield::transferdata(int physreg, vectorfieldselect myvec, std::string op
         selecteddisjregs = dofmngr->getdisjointregionsofselectedfield();
     }
 
-    for (int i = 0; i < selecteddisjregs.size(); i++)
+    for (size_t i = 0; i < selecteddisjregs.size(); i++)
     {
         int disjreg = selecteddisjregs[i];
 
@@ -1306,7 +1306,7 @@ std::shared_ptr<rawfield> rawfield::harmonic(const std::vector<int> harmonicnumb
         std::shared_ptr<rawfield> harmsrawfield(new rawfield());
         *harmsrawfield = *this;
         // Replace every subfield by a new one with only the requested harmonics:
-        for (int i = 0; i < mysubfields.size(); i++)
+        for (size_t i = 0; i < mysubfields.size(); i++)
             harmsrawfield->mysubfields[i][0] = mysubfields[i][0]->harmonic(harmonicnumbers);
         return harmsrawfield;
     }
@@ -1334,7 +1334,7 @@ std::shared_ptr<rawfield> rawfield::harmonic(const std::vector<int> harmonicnumb
         harmsrawfield->myharmonics = std::vector<std::vector<std::shared_ptr<rawfield>>>(maxharmnum+1, std::vector<std::shared_ptr<rawfield>>(0));
         
         // Add only the requested harmonics:
-        for (int i = 0; i < harmonicnumbers.size(); i++)
+        for (size_t i = 0; i < harmonicnumbers.size(); i++)
         {
             if (harmonicnumbers[i] < myharmonics.size() && myharmonics[harmonicnumbers[i]].size() > 0)
                 harmsrawfield->myharmonics[harmonicnumbers[i]] = {myharmonics[harmonicnumbers[i]][0]};
@@ -1556,7 +1556,7 @@ void rawfield::errornotsameinterpolationorder(int disjreg)
         if (myharmonics.size() > 0)
         {
             std::vector<int> harms = getharmonics();
-            for (int h = 0; h < harms.size(); h++)
+            for (size_t h = 0; h < harms.size(); h++)
             {
                 if (myharmonics[harms[h]][0]->getinterpolationorder(disjreg) == myharmonics[harms[0]][0]->getinterpolationorder(disjreg))
                     continue;
@@ -1584,12 +1584,12 @@ std::vector<std::pair<std::vector<int>, std::shared_ptr<rawfield>>> rawfield::ge
     
     if (mysubfields.size() > 0)
     {
-        for (int i = 0; i < mysubfields.size(); i++)
+        for (size_t i = 0; i < mysubfields.size(); i++)
         {
             if (mysubfields[i].size() > 0)
             {
                 std::vector<std::pair<std::vector<int>, std::shared_ptr<rawfield>>> cur = mysubfields[i][0]->getallsons();
-                for (int f = 0; f < cur.size(); f++)
+                for (size_t f = 0; f < cur.size(); f++)
                 {
                     cur[f].first[0] = i;
                     output.push_back(cur[f]);
@@ -1601,12 +1601,12 @@ std::vector<std::pair<std::vector<int>, std::shared_ptr<rawfield>>> rawfield::ge
     
     if (myharmonics.size() > 0)
     {
-        for (int h = 0; h < myharmonics.size(); h++)
+        for (size_t h = 0; h < myharmonics.size(); h++)
         {
             if (myharmonics[h].size() > 0)
             {
                 std::vector<std::pair<std::vector<int>, std::shared_ptr<rawfield>>> cur = myharmonics[h][0]->getallsons();
-                for (int f = 0; f < cur.size(); f++)
+                for (size_t f = 0; f < cur.size(); f++)
                 {
                     cur[f].first[1] = h;
                     output.push_back(cur[f]);
@@ -1737,17 +1737,17 @@ void rawfield::writeraw(int physreg, std::string filename, bool isbinary, std::v
     std::vector<double> flatdoubledata(doubledatasize);
     
     int curindex = 0;
-    for (int i = 0; i < extradata.size(); i++)
+    for (size_t i = 0; i < extradata.size(); i++)
     {
         flatdoubledata[curindex] = extradata[i];
         curindex++;
     }
     
-    for (int i = 0; i < doubledata.size(); i++)
+    for (size_t i = 0; i < doubledata.size(); i++)
     {
-        for (int j = 0; j < doubledata[i].size(); j++)
+        for (size_t j = 0; j < doubledata[i].size(); j++)
         {
-            for (int k = 0; k < doubledata[i][j].size(); k++)
+            for (size_t k = 0; k < doubledata[i][j].size(); k++)
             {
                 flatdoubledata[curindex] = doubledata[i][j][k];
                 curindex++;
@@ -1815,12 +1815,12 @@ std::vector<double> rawfield::loadraw(std::string filename, bool isbinary)
         std::cout << "Error in 'rawfield' object: harmonic list in field loaded from file '" << filename << "' does not match current field." << std::endl << std::endl;
 
         std::cout << "Harmonics in loaded field (" << harmoniclist.size() << "): ";
-        for (int i = 0; i < harmoniclist.size(); i++)
+        for (size_t i = 0; i < harmoniclist.size(); i++)
             std::cout << harmoniclist[i] << " ";
         std::cout << std::endl;
         
         std::cout << "Harmonics in current field (" << harmsinthisfield.size() << "): ";
-        for (int i = 0; i < harmsinthisfield.size(); i++)
+        for (size_t i = 0; i < harmsinthisfield.size(); i++)
             std::cout << harmsinthisfield[i] << " ";
         std::cout << std::endl << std::endl;
         abort();
@@ -1865,7 +1865,7 @@ std::vector<double> rawfield::loadraw(std::string filename, bool isbinary)
     
     // Load the extra data at the double data vector begin:
     std::vector<double> extradata(intdata[indexinintvec+1]);
-    for (int i = 0; i < extradata.size(); i++)
+    for (size_t i = 0; i < extradata.size(); i++)
         extradata[i] = doubledata[i];
     
     // Calculate the number of sons:
@@ -1953,7 +1953,7 @@ std::vector<densematrix> rawfield::getjacterms(elementselector& elemselect, std:
 
     for (int num = 0; num < numcurvednodes; num++)
     {
-        for (int i = 0; i < elementlist.size(); i++)
+        for (size_t i = 0; i < elementlist.size(); i++)
         {
             int elem = elementlist[i];
             // Get the node to which the current form function is associated:
@@ -1994,7 +1994,7 @@ std::vector<std::vector<densematrix>> rawfield::interpolate(int whichderivative,
 
     // Group disj. regs. with same interpolation order (and same element type number).
     std::vector<int> interpolorders(alldisjregs.size());
-    for (int i = 0; i < alldisjregs.size(); i++)
+    for (size_t i = 0; i < alldisjregs.size(); i++)
         interpolorders[i] = getinterpolationorder(alldisjregs[i]);
     disjointregionselector mydisjregselector(alldisjregs, {interpolorders});
     for (int i = 0; i < mydisjregselector.countgroups(); i++)
@@ -2011,14 +2011,14 @@ std::vector<std::vector<densematrix>> rawfield::interpolate(int whichderivative,
         // Preallocate the harmonics not in 'out':
         if (out.size() < currentinterp.size())
             out.resize(currentinterp.size());
-        for (int h = 0; h < currentinterp.size(); h++)
+        for (size_t h = 0; h < currentinterp.size(); h++)
         {
             if (currentinterp[h].size() == 1 && out[h].size() == 0)
                 out[h] = {densematrix(elemselect.countincurrentorientation(), evaluationcoordinates.size()/3, 0)};
         }
         
         // Insert 'currentinterp' in 'out':
-        for (int h = 0; h < currentinterp.size(); h++)
+        for (size_t h = 0; h < currentinterp.size(); h++)
         {
             if (currentinterp[h].size() == 1)
                 out[h][0].insertatrows(elemselect.getelementindexes(), currentinterp[h][0]);
@@ -2059,7 +2059,7 @@ densematrix rawfield::getcoefficients(int elementtypenumber, int interpolorder, 
 
         for (int num = 0; num < numcurvednodes; num++)
         {
-            for (int i = 0; i < elementlist.size(); i++)
+            for (size_t i = 0; i < elementlist.size(); i++)
             {
                 int elem = elementlist[i];
                 // Get the node to which the current form function is associated:
@@ -2092,7 +2092,7 @@ densematrix rawfield::getcoefficients(int elementtypenumber, int interpolorder, 
             if ((elementtypenumber == 6 || elementtypenumber == 7) && associatedelementtype == 3)
                 num -= myelement.counttriangularfaces();
 
-            for (int i = 0; i < elementlist.size(); i++)
+            for (size_t i = 0; i < elementlist.size(); i++)
             {
                 int elem = elementlist[i];
                 // Get the subelement to which the current form function is associated:
@@ -2152,7 +2152,7 @@ std::vector<std::vector<densematrix>> rawfield::interpolate(int whichderivative,
         {
             std::vector<std::vector<densematrix>> coefstimesformfunctions(myharmonics.size());
 
-            for (int harm = 1; harm < myharmonics.size(); harm++)
+            for (size_t harm = 1; harm < myharmonics.size(); harm++)
             {
                 if (myharmonics[harm].size() == 0)
                     continue;

--- a/src/formulation/contribution.cpp
+++ b/src/formulation/contribution.cpp
@@ -44,11 +44,11 @@ void contribution::generate(std::shared_ptr<rawvec> myvec, std::shared_ptr<rawma
     std::vector<int> tfinterpolorders(selectedelemdisjregs.size());
     std::vector<int> dofinterpolorders(selectedelemdisjregs.size(),0);
     // All harmonics must have the same interpolation order!
-    for (int i = 0; i < selectedelemdisjregs.size(); i++)
+    for (size_t i = 0; i < selectedelemdisjregs.size(); i++)
         tfinterpolorders[i] = tffield->getinterpolationorder(selectedelemdisjregs[i]);
     if (doffield != NULL)
     {
-        for (int i = 0; i < selectedelemdisjregs.size(); i++)
+        for (size_t i = 0; i < selectedelemdisjregs.size(); i++)
             dofinterpolorders[i] = doffield->getinterpolationorder(selectedelemdisjregs[i]);
     }
     
@@ -102,7 +102,7 @@ void contribution::generate(std::shared_ptr<rawvec> myvec, std::shared_ptr<rawma
         bool isorientationdependent = tfformfunction->isorientationdependent(tfinterpolationorder);
         if (doffield != NULL)
             isorientationdependent = isorientationdependent || dofformfunction->isorientationdependent(dofinterpolationorder);
-        for (int term = 0; term < mytfs.size(); term++)
+        for (size_t term = 0; term < mytfs.size(); term++)
         {
             mycoeffs[term] = mycoeffs[term]->simplify(mydisjregs);
             isorientationdependent = (isorientationdependent || mycoeffs[term]->isvalueorientationdependent(mydisjregs) || (meshdeformationptr != NULL && meshdeformationptr->isvalueorientationdependent(mydisjregs)));
@@ -135,7 +135,7 @@ void contribution::generate(std::shared_ptr<rawvec> myvec, std::shared_ptr<rawma
             
             // Compute all terms in the contribution sum:
             densematrix tfformfunctionvalue, dofformfunctionvalue;
-            for (int term = 0; term < mytfs.size(); term++)
+            for (size_t term = 0; term < mytfs.size(); term++)
             {
                 ///// Compute the coefficients:
                 // currentcoeff[i][0] holds the ith harmonic of the coefficient. 
@@ -175,7 +175,7 @@ void contribution::generate(std::shared_ptr<rawvec> myvec, std::shared_ptr<rawma
 
                 ///// Since the interpolation orders are identical for all harmonics
                 // we can premultiply all coefficients by the same dof*tf product.
-                for (int h = 0; h < currentcoeff.size(); h++)
+                for (size_t h = 0; h < currentcoeff.size(); h++)
                 {
                     if (currentcoeff[h].size() > 0)
                     {
@@ -200,18 +200,18 @@ void contribution::generate(std::shared_ptr<rawvec> myvec, std::shared_ptr<rawma
                     multiharmonicdoftimederivativeorder = mydofs[term]->gettimederivative();
 
                 ///// Add the term to the corresponding stiffness block:
-                for (int currentcoefharm = 0; currentcoefharm < currentcoeff.size(); currentcoefharm++)
+                for (size_t currentcoefharm = 0; currentcoefharm < currentcoeff.size(); currentcoefharm++)
                 {
                     if (currentcoeff[currentcoefharm].size() == 0)
                         continue;
                     
-                    for (int dofharmindex = 0; dofharmindex < dofharms.size(); dofharmindex++)
+                    for (size_t dofharmindex = 0; dofharmindex < dofharms.size(); dofharmindex++)
                     {
                         int currentdofharm = dofharms[dofharmindex];
                         // Perform the product of the coefficient and the dof harmonic:
                         std::vector<std::pair<int, double>> harmsofproduct = harmonic::getproduct(currentcoefharm, currentdofharm, multiharmonicdoftimederivativeorder);
                         // Loop on all product harmonics:
-                        for (int p = 0; p < harmsofproduct.size(); p++)
+                        for (size_t p = 0; p < harmsofproduct.size(); p++)
                         {
                             int currentharm = harmsofproduct[p].first;
                             // currentharmcoef can be + or - 0.5 or 1 (+ the time derivation factor).
@@ -234,11 +234,11 @@ void contribution::generate(std::shared_ptr<rawvec> myvec, std::shared_ptr<rawma
             universe::forbidreuse();
             
             // Get the adresses of all stiffnesses in the assembled matrix.
-            for (int htf = 0; htf < tfharms.size(); htf++)
+            for (size_t htf = 0; htf < tfharms.size(); htf++)
             {
                 int currenttfharm = tfharms[htf];
 
-                for (int hdof = 0; hdof < dofharms.size(); hdof++)
+                for (size_t hdof = 0; hdof < dofharms.size(); hdof++)
                 {
                     int currentdofharm = dofharms[hdof];
                     

--- a/src/formulation/dofinterpolate.cpp
+++ b/src/formulation/dofinterpolate.cpp
@@ -73,7 +73,7 @@ dofinterpolate::dofinterpolate(std::vector<double> refcoords, elementselector& e
 
     // Calculate the maximum number of shape functions over all disjoint regions for preallocation.
     mymaxnumff = 0;
-    for (int i = 0; i < ondisjregs.size(); i++)
+    for (size_t i = 0; i < ondisjregs.size(); i++)
     {
         int elementtypenumber = (universe::mymesh->getdisjointregions())->getelementtypenumber(ondisjregs[i]); 
         int doforder = mydoffield->getinterpolationorder(ondisjregs[i]);
@@ -87,13 +87,13 @@ dofinterpolate::dofinterpolate(std::vector<double> refcoords, elementselector& e
     // Preallocate the matrix containers:
     int totalnumels = elemselec.count();
     myvals = std::vector<densematrix>(mydofops.size());
-    for (int i = 0; i < mydofops.size(); i++)
+    for (size_t i = 0; i < mydofops.size(); i++)
         myvals[i] = densematrix(totalnumels, mymaxnumff*mynumrefcoords, 0);
     // Preallocate the adresses matrix for each harmonic:
     std::vector<int> dofharms = mydoffield->getharmonics();
     mydofnums = std::vector<std::vector<intdensematrix>>(*std::max_element(dofharms.begin(), dofharms.end()) + 1, std::vector<intdensematrix>(0));
    
-    for (int h = 0; h < dofharms.size(); h++)
+    for (size_t h = 0; h < dofharms.size(); h++)
         mydofnums[dofharms[h]] = {intdensematrix(totalnumels, mymaxnumff*mynumrefcoords, -2)};
            
 
@@ -110,7 +110,7 @@ void dofinterpolate::eval(void)
     std::vector<int> dofharms = mydoffield->getharmonics();
     
     std::vector<int> dofinterpolorders(ondisjregs.size());
-    for (int i = 0; i < ondisjregs.size(); i++)
+    for (size_t i = 0; i < ondisjregs.size(); i++)
         dofinterpolorders[i] = mydoffield->getinterpolationorder(ondisjregs[i]);
 
 
@@ -161,7 +161,7 @@ void dofinterpolate::eval(void)
             // Evaluate the shape functions for all total orientations and all reference derivatives:
             hfc.evaluate(kietaphi);
             
-            for (int h = 0; h < dofharms.size(); h++)
+            for (size_t h = 0; h < dofharms.size(); h++)
             {
                 mydofmanager->selectfield(mydoffield->harmonic(dofharms[h]));
                 int* dofnumsptr = mydofnums[dofharms[h]][0].getvalues();
@@ -179,12 +179,12 @@ void dofinterpolate::eval(void)
                     std::vector<densematrix> evaled(mydofops.size());
                     if (h == 0)
                     {
-                        for (int df = 0; df < mydofops.size(); df++)
+                        for (size_t df = 0; df < mydofops.size(); df++)
                             evaled[df] = hfc.tomatrix(totalorient, doforder, mydofops[df]->getkietaphiderivative(), mydofops[df]->getformfunctioncomponent());
                     }
                     
                     // Loop on all selected elements:
-                    for (int e = 0; e < elems.size(); e++)
+                    for (size_t e = 0; e < elems.size(); e++)
                     {
                         for (int ep = 0; ep < numrefcoords; ep++)
                         {
@@ -200,7 +200,7 @@ void dofinterpolate::eval(void)
                             // Same for all harmonics. Do it only once.
                             if (h == 0)
                             {
-                                for (int df = 0; df < mydofops.size(); df++)
+                                for (size_t df = 0; df < mydofops.size(); df++)
                                 {
                                     for (int ff = 0; ff < curnumff; ff++)
                                         myvals[df].getvalues()[rowstart+mynumrefcoords*ff+callingevalpt] = evaled[df].getvalues()[ff*numrefcoords+ep];
@@ -228,7 +228,7 @@ void dofinterpolate::eval(void)
                 while (myselector.next());
             }
             // Keep track of which coordinates were found:
-            for (int c = 0; c < coordindexes.size(); c++)
+            for (size_t c = 0; c < coordindexes.size(); c++)
                 isfound[coordindexes[c]] = true;
         }
     }
@@ -236,7 +236,7 @@ void dofinterpolate::eval(void)
     // Do something if some coordinates were not found:
     if (mydofops[0]->getoncontext()->iserrorifnotfound())
     {
-        for (int i = 0; i < isfound.size(); i++)
+        for (size_t i = 0; i < isfound.size(); i++)
         {    
             if (isfound[i] == false)
             {

--- a/src/formulation/dofmanager.cpp
+++ b/src/formulation/dofmanager.cpp
@@ -18,7 +18,7 @@ void dofmanager::synchronize(void)
     rangeend = {};
 
     // Rebuild the structure:
-    for (int i = 0; i < mystructuretracker.size(); i++)
+    for (size_t i = 0; i < mystructuretracker.size(); i++)
         addtostructure(mystructuretracker[i].first, mystructuretracker[i].second);
     
     // Select the same field again:
@@ -36,7 +36,7 @@ void dofmanager::addtostructure(std::shared_ptr<rawfield> fieldtoadd, std::vecto
 
     // Find the field index of 'fieldtoadd' (if present):
     int fieldindex = -1;
-    for (int i = 0; i < myfields.size(); i++)
+    for (size_t i = 0; i < myfields.size(); i++)
     {
         if (myfields[i].get() == fieldtoadd.get())
         {
@@ -69,7 +69,7 @@ void dofmanager::addtostructure(std::shared_ptr<rawfield> fieldtoadd, std::vecto
     }
     
     // Add an entry for every form function - if not already existing:
-    for (int i = 0; i < selecteddisjointregions.size(); i++)
+    for (size_t i = 0; i < selecteddisjointregions.size(); i++)
     {
         int disjreg = selecteddisjointregions[i];
         
@@ -136,7 +136,7 @@ void dofmanager::selectfield(std::shared_ptr<rawfield> selectedfield)
     synchronize();
     
     selectedfieldnumber = -1;
-    for (int i = 0; i < myfields.size(); i++)
+    for (size_t i = 0; i < myfields.size(); i++)
     {
         if (myfields[i].get() == selectedfield.get())
         {
@@ -164,7 +164,7 @@ std::vector<int> dofmanager::getdisjointregionsofselectedfield(void)
     
     std::vector<int> output(rangebegin[selectedfieldnumber].size());
     int index = 0;
-    for (int i = 0; i < output.size(); i++)
+    for (size_t i = 0; i < output.size(); i++)
     {
         if (rangebegin[selectedfieldnumber][i].size() > 0)
         {
@@ -204,9 +204,9 @@ int dofmanager::countconstraineddofs(void)
     
     int numconstraineddofs = 0;
     
-    for (int fieldindex = 0; fieldindex < rangebegin.size(); fieldindex++)
+    for (size_t fieldindex = 0; fieldindex < rangebegin.size(); fieldindex++)
     {
-        for (int disjreg = 0; disjreg < rangebegin[fieldindex].size(); disjreg++)
+        for (size_t disjreg = 0; disjreg < rangebegin[fieldindex].size(); disjreg++)
         {
             // If the field is constrained on the disjoint region and there is at least one form function:
             if (rangebegin[fieldindex][disjreg].size() > 0 && myfields[fieldindex]->isconstrained(disjreg))
@@ -224,14 +224,14 @@ intdensematrix dofmanager::getconstrainedindexes(void)
     int* myval = output.getvalues();
     
     int currentindex = 0;
-    for (int fieldindex = 0; fieldindex < rangebegin.size(); fieldindex++)
+    for (size_t fieldindex = 0; fieldindex < rangebegin.size(); fieldindex++)
     {
-        for (int disjreg = 0; disjreg < rangebegin[fieldindex].size(); disjreg++)
+        for (size_t disjreg = 0; disjreg < rangebegin[fieldindex].size(); disjreg++)
         {
             // If the field is constrained on the disjoint region.
             if (myfields[fieldindex]->isconstrained(disjreg))
             {
-                for (int ff = 0; ff < rangebegin[fieldindex][disjreg].size(); ff++)
+                for (size_t ff = 0; ff < rangebegin[fieldindex][disjreg].size(); ff++)
                 {
                     int numdofshere = rangeend[fieldindex][disjreg][0] - rangebegin[fieldindex][disjreg][0] + 1;
                     for (int i = 0; i < numdofshere; i++)
@@ -252,9 +252,9 @@ int dofmanager::countgaugeddofs(void)
     
     int numgaugeddofs = 0;
     
-    for (int fieldindex = 0; fieldindex < rangebegin.size(); fieldindex++)
+    for (size_t fieldindex = 0; fieldindex < rangebegin.size(); fieldindex++)
     {
-        for (int disjreg = 0; disjreg < rangebegin[fieldindex].size(); disjreg++)
+        for (size_t disjreg = 0; disjreg < rangebegin[fieldindex].size(); disjreg++)
         {
             // Constraints have priority over the gauge!
             if (myfields[fieldindex]->isconstrained(disjreg) == false && myfields[fieldindex]->isgauged(disjreg))
@@ -266,7 +266,7 @@ int dofmanager::countgaugeddofs(void)
                 std::shared_ptr<hierarchicalformfunction> formfunc = selector::select(elementtype, myfields[fieldindex]->gettypename());
                 std::vector<bool> isitgradienttype = formfunc->isgradienttype(fieldorder);
        
-                for (int ff = 0; ff < rangebegin[fieldindex][disjreg].size(); ff++)
+                for (size_t ff = 0; ff < rangebegin[fieldindex][disjreg].size(); ff++)
                 {
                     // The lowest order hcurl form function is gauged only on the spanning tree:
                     if (elementtype == 1 && ff == 0)
@@ -292,9 +292,9 @@ intdensematrix dofmanager::getgaugedindexes(void)
     int* myval = output.getvalues();
     
     int currentindex = 0;
-    for (int fieldindex = 0; fieldindex < rangebegin.size(); fieldindex++)
+    for (size_t fieldindex = 0; fieldindex < rangebegin.size(); fieldindex++)
     {
-        for (int disjreg = 0; disjreg < rangebegin[fieldindex].size(); disjreg++)
+        for (size_t disjreg = 0; disjreg < rangebegin[fieldindex].size(); disjreg++)
         {
             // Constraints have priority over the gauge!
             if (myfields[fieldindex]->isconstrained(disjreg) == false && myfields[fieldindex]->isgauged(disjreg))
@@ -306,7 +306,7 @@ intdensematrix dofmanager::getgaugedindexes(void)
                 std::shared_ptr<hierarchicalformfunction> formfunc = selector::select(elementtype, myfields[fieldindex]->gettypename());
                 std::vector<bool> isitgradienttype = formfunc->isgradienttype(fieldorder);
        
-                for (int ff = 0; ff < rangebegin[fieldindex][disjreg].size(); ff++)
+                for (size_t ff = 0; ff < rangebegin[fieldindex][disjreg].size(); ff++)
                 {
                     // The lowest order hcurl form function is gauged only on the spanning tree.
                     // All other form functions are gauged on all dofs in the disjoint region.
@@ -336,11 +336,11 @@ std::pair<intdensematrix, densematrix> dofmanager::getconditionalconstraintdata(
     std::vector<densematrix> constrvalvec = {};
     
     
-    for (int fieldindex = 0; fieldindex < rangebegin.size(); fieldindex++)
+    for (size_t fieldindex = 0; fieldindex < rangebegin.size(); fieldindex++)
     {
         // First get the list of disjoint NODE regions on which the rawfield is conditionally constrained:
         std::vector<bool> isdisjregactive(rangebegin[fieldindex].size(), false);
-        for (int disjreg = 0; disjreg < isdisjregactive.size(); disjreg++)
+        for (size_t disjreg = 0; disjreg < isdisjregactive.size(); disjreg++)
         {
             // Only the nodes are constrained:
             if (rangebegin[fieldindex][disjreg].size() == 0 || universe::mymesh->getdisjointregions()->getelementtypenumber(disjreg) != 0)
@@ -355,7 +355,7 @@ std::pair<intdensematrix, densematrix> dofmanager::getconditionalconstraintdata(
         std::vector<std::vector<expression>> condconstrexpr = myfields[fieldindex]->getconditionalconstraints();
     
         // Loop on all disjoint regions:
-        for (int disjreg = 0; disjreg < isdisjregactive.size(); disjreg++)
+        for (size_t disjreg = 0; disjreg < isdisjregactive.size(); disjreg++)
         {
             if (isdisjregactive[disjreg] == false)
                 continue;
@@ -364,7 +364,7 @@ std::pair<intdensematrix, densematrix> dofmanager::getconditionalconstraintdata(
             
             // Combine all disjoint regions that share the same condop and constrop operations:
             std::vector<int> curdisjregs = {};
-            for (int i = disjreg; i < isdisjregactive.size(); i++)
+            for (size_t i = disjreg; i < isdisjregactive.size(); i++)
             {
                 if (isdisjregactive[i] && condop == condconstrexpr[i][0].getoperationinarray(0,0) && constrop == condconstrexpr[i][1].getoperationinarray(0,0))
                 {
@@ -388,7 +388,7 @@ std::pair<intdensematrix, densematrix> dofmanager::getconditionalconstraintdata(
             intdensematrix curindexmat(condval[1][0].countrows(), condval[1][0].countcolumns(),0);
             int* curindexmatptr = curindexmat.getvalues();
             int index = 0;
-            for (int i = 0; i < curdisjregs.size(); i++)
+            for (size_t i = 0; i < curdisjregs.size(); i++)
             {
                 // There is only a single shape function per node!
                 for (int ind = rangebegin[fieldindex][curdisjregs[i]][0]; ind <= rangeend[fieldindex][curdisjregs[i]][0]; ind++)
@@ -407,7 +407,7 @@ std::pair<intdensematrix, densematrix> dofmanager::getconditionalconstraintdata(
 
     // Count the number of active conditional constraints:
     int numactive = 0;
-    for (int i = 0; i < condvalvec.size(); i++)
+    for (size_t i = 0; i < condvalvec.size(); i++)
     {
         double* condvalptr = condvalvec[i].getvalues();
         for (int j = 0; j < condvalvec[i].count(); j++)
@@ -425,7 +425,7 @@ std::pair<intdensematrix, densematrix> dofmanager::getconditionalconstraintdata(
     double* valptr = condconstrval.getvalues();
     
     int index = 0;
-    for (int i = 0; i < condvalvec.size(); i++)
+    for (size_t i = 0; i < condvalvec.size(); i++)
     {
         double* condvalptr = condvalvec[i].getvalues();
         double* constrvalptr = constrvalvec[i].getvalues();
@@ -458,14 +458,14 @@ std::shared_ptr<dofmanager> dofmanager::removeconstraints(int* dofrenumbering)
     *(newdofmanager.get()) = *this;
     newdofmanager->numberofdofs = 0;
     
-    for (int fieldindex = 0; fieldindex < newdofmanager->rangebegin.size(); fieldindex++)
+    for (size_t fieldindex = 0; fieldindex < newdofmanager->rangebegin.size(); fieldindex++)
     {
-        for (int disjreg = 0; disjreg < newdofmanager->rangebegin[fieldindex].size(); disjreg++)
+        for (size_t disjreg = 0; disjreg < newdofmanager->rangebegin[fieldindex].size(); disjreg++)
         {
             // If the field is not constrained on the disjoint region:
             if (newdofmanager->myfields[fieldindex]->isconstrained(disjreg) == false)
             {
-                for (int ff = 0; ff < newdofmanager->rangebegin[fieldindex][disjreg].size(); ff++)
+                for (size_t ff = 0; ff < newdofmanager->rangebegin[fieldindex][disjreg].size(); ff++)
                 {
                     // Update the range begin and end:
                     int numdofshere = newdofmanager->rangeend[fieldindex][disjreg][0] - newdofmanager->rangebegin[fieldindex][disjreg][0] + 1;
@@ -544,9 +544,9 @@ void dofmanager::print(void)
     
     std::cout << "Showing the content of the dof manager (" << numberofdofs << " dofs in total):" << std::endl << std::endl;
     
-    for (int i = 0; i < myfields.size(); i++)
+    for (size_t i = 0; i < myfields.size(); i++)
     {
-        for (int disjreg = 0; disjreg < rangebegin[i].size(); disjreg++)
+        for (size_t disjreg = 0; disjreg < rangebegin[i].size(); disjreg++)
         {
             // Only print not-empty entries:
             if (rangebegin[i][disjreg].size() != 0)
@@ -572,7 +572,7 @@ intdensematrix dofmanager::getadresses(std::shared_ptr<rawfield> inputfield, int
     // on the disjoint region number i and false otherwise.
     std::vector<int> fielddisjregs = ((universe::mymesh->getphysicalregions())->get(fieldphysreg))->getdisjointregions(-1); // Get all disj regs with (-1)
     std::vector<bool> isfielddefinedondisjointregion(mydisjointregions->count(),false);
-    for (int i = 0; i < fielddisjregs.size(); i++)
+    for (size_t i = 0; i < fielddisjregs.size(); i++)
         isfielddefinedondisjointregion[fielddisjregs[i]] = true;
                     
     element myelement(elementtypenumber);
@@ -601,7 +601,7 @@ intdensematrix dofmanager::getadresses(std::shared_ptr<rawfield> inputfield, int
         std::shared_ptr<hierarchicalformfunction> myformfunction = selector::select(elementtypenumber, inputfield->gettypename());
         int currentnumberofformfunctions, previousdisjreg;       
 
-        for (int i = 0; i < elementlist.size(); i++)
+        for (size_t i = 0; i < elementlist.size(); i++)
         {
             int elem = elementlist[i];
             // Get the subelement to which the current form function is associated:

--- a/src/formulation/formulation.cpp
+++ b/src/formulation/formulation.cpp
@@ -5,7 +5,7 @@ formulation::formulation(void) { mydofmanager = std::shared_ptr<dofmanager>(new 
 
 void formulation::operator+=(std::vector<integration> integrationobject)
 {
-    for (int i = 0; i < integrationobject.size(); i++)
+    for (size_t i = 0; i < integrationobject.size(); i++)
         *this += integrationobject[i];
 }
 
@@ -33,7 +33,7 @@ void formulation::operator+=(integration integrationobject)
     std::vector<std::vector<std::shared_ptr<operation>>> tfs = coeffdoftf[2];
 
     // Loop on all slices:
-    for (int slice = 0; slice < tfs.size(); slice++)
+    for (size_t slice = 0; slice < tfs.size(); slice++)
     {
         // In a given slice all dof and tf fields are the same, have the 
         // same applied time derivatives and are selected on a same 
@@ -67,11 +67,11 @@ void formulation::operator+=(integration integrationobject)
         if (doffield != NULL && dofs[slice][0]->ison() == false)
         {
             std::vector<int> dofharms = doffield->getharmonics();
-            for (int h = 0; h < dofharms.size(); h++)
+            for (size_t h = 0; h < dofharms.size(); h++)
                 mydofmanager->addtostructure(doffield->harmonic(dofharms[h]), dofphysreg);
         }
         std::vector<int> tfharms = tffield->getharmonics();
-        for (int h = 0; h < tfharms.size(); h++)
+        for (size_t h = 0; h < tfharms.size(); h++)
             mydofmanager->addtostructure(tffield->harmonic(tfharms[h]), tfphysreg);
 
         // Create the contribution:
@@ -148,7 +148,7 @@ void formulation::generate(int m, int contributionnumber)
         mymat[m-1] = std::shared_ptr<rawmat>(new rawmat(mydofmanager));
 
     std::vector<contribution> contributionstogenerate = mycontributions[m][contributionnumber];
-    for (int i = 0; i < contributionstogenerate.size(); i++)
+    for (size_t i = 0; i < contributionstogenerate.size(); i++)
     {
         if (m == 0)
             contributionstogenerate[i].generate(myvec, NULL, not(isconstraintcomputation));
@@ -162,9 +162,9 @@ void formulation::generate(int m, int contributionnumber)
 
 void formulation::generate(void)
 {
-    for (int i = 0; i < mycontributions.size(); i++)
+    for (size_t i = 0; i < mycontributions.size(); i++)
     {
-        for (int j = 0; j < mycontributions[i].size(); j++)
+        for (size_t j = 0; j < mycontributions[i].size(); j++)
             generate(i, j);
     }
 }
@@ -172,44 +172,44 @@ void formulation::generate(void)
 void formulation::generatestiffnessmatrix(void)
 {
     int i = 1;
-    for (int j = 0; j < mycontributions[i].size(); j++)
+    for (size_t j = 0; j < mycontributions[i].size(); j++)
         generate(i, j);
 }
 
 void formulation::generatedampingmatrix(void)
 {
     int i = 2;
-    for (int j = 0; j < mycontributions[i].size(); j++)
+    for (size_t j = 0; j < mycontributions[i].size(); j++)
         generate(i, j);
 }
 
 void formulation::generatemassmatrix(void)
 {
     int i = 3;
-    for (int j = 0; j < mycontributions[i].size(); j++)
+    for (size_t j = 0; j < mycontributions[i].size(); j++)
         generate(i, j);
 }
 
 void formulation::generaterhs(void)
 {
     int i = 0;
-    for (int j = 0; j < mycontributions[i].size(); j++)
+    for (size_t j = 0; j < mycontributions[i].size(); j++)
         generate(i, j);
 }
 
 
 void formulation::generate(std::vector<int> contributionnumbers)
 {
-    for (int i = 0; i < mycontributions.size(); i++)
+    for (size_t i = 0; i < mycontributions.size(); i++)
     {
-        for (int j = 0; j < contributionnumbers.size(); j++)
+        for (size_t j = 0; j < contributionnumbers.size(); j++)
             generate(i, contributionnumbers[j]);
     }
 }
 
 void formulation::generate(int contributionnumber)
 {
-    for (int i = 0; i < mycontributions.size(); i++)
+    for (size_t i = 0; i < mycontributions.size(); i++)
             generate(i, contributionnumber);
 }
 

--- a/src/formulation/mat.cpp
+++ b/src/formulation/mat.cpp
@@ -59,7 +59,7 @@ void mat::permute(intdensematrix rowpermute, intdensematrix colpermute)
     rawmatptr = std::shared_ptr<rawmat>(new rawmat(rawmatptr->getdofmanager(), permutedmat));
 }
 
-void mat::removeconstraints(void) { errorifpointerisnull(); errorifinvalidated(); rawmatptr->removeconstraints(); };
+void mat::removeconstraints(void) { errorifpointerisnull(); errorifinvalidated(); rawmatptr->removeconstraints(); }
 
 void mat::reusefactorization(void) { errorifpointerisnull(); errorifinvalidated(); rawmatptr->reuselu(); }
 
@@ -69,7 +69,7 @@ std::shared_ptr<rawmat> mat::getpointer(void)
     return rawmatptr;
 }
         
-Mat mat::getpetsc(void) { errorifpointerisnull(); errorifinvalidated(); return rawmatptr->getpetsc(); }   
+Mat mat::getpetsc(void) { errorifpointerisnull(); errorifinvalidated(); return rawmatptr->getpetsc(); }
 
 void mat::print(void) { errorifpointerisnull(); errorifinvalidated(); rawmatptr->print(); }
 

--- a/src/formulation/rawmat.cpp
+++ b/src/formulation/rawmat.cpp
@@ -63,7 +63,7 @@ void rawmat::zeroentries(intdensematrix entriestozero, bool zerorows, bool zeroc
             
         if (zerorows)
         {
-            for (int i = 0; i < accumulatedrowindices.size(); i++)
+            for (size_t i = 0; i < accumulatedrowindices.size(); i++)
             {
                 int* accumulatedrowindicesptr = accumulatedrowindices[i].getvalues();
                 for (long long int j = 0; j < accumulatedrowindices[i].count(); j++)
@@ -75,7 +75,7 @@ void rawmat::zeroentries(intdensematrix entriestozero, bool zerorows, bool zeroc
         }
         if (zerocolumns)
         {
-            for (int i = 0; i < accumulatedcolindices.size(); i++)
+            for (size_t i = 0; i < accumulatedcolindices.size(); i++)
             {
                 int* accumulatedcolindicesptr = accumulatedcolindices[i].getvalues();
                 for (long long int j = 0; j < accumulatedcolindices[i].count(); j++)
@@ -161,7 +161,7 @@ void rawmat::process(void)
     // Concatenate all accumulated fragments!
     // Remove negative indexes. First get the overall length.
     long long int veclen = 0;
-    for (int i = 0; i < accumulatedvals.size(); i++)
+    for (size_t i = 0; i < accumulatedvals.size(); i++)
     {
         int* accumulatedrowindicesptr = accumulatedrowindices[i].getvalues();
         int* accumulatedcolindicesptr = accumulatedcolindices[i].getvalues();
@@ -177,7 +177,7 @@ void rawmat::process(void)
     std::vector<std::tuple<int,int,double>> tupl(veclen);
     
     long long int ind = 0;
-    for (int i = 0; i < accumulatedvals.size(); i++)
+    for (size_t i = 0; i < accumulatedvals.size(); i++)
     {
         double* valsptr = accumulatedvals[i].getvalues();
         int* accumulatedrowindicesptr = accumulatedrowindices[i].getvalues();

--- a/src/formulation/rawvec.cpp
+++ b/src/formulation/rawvec.cpp
@@ -17,7 +17,7 @@ void rawvec::synchronize(void)
         dm = *mydofmanager; // backup
         *mydofmanager = mycurrentstructure[0];
         
-        for (int i = 0; i < dmfields.size(); i++)
+        for (size_t i = 0; i < dmfields.size(); i++)
         {
             mydofmanager->selectfield(dmfields[i]);
             mycurrentstructure[0].selectfield(dmfields[i]);
@@ -31,7 +31,7 @@ void rawvec::synchronize(void)
           
         *mydofmanager = dm; // restore
         
-        for (int i = 0; i < dmfields.size(); i++)
+        for (size_t i = 0; i < dmfields.size(); i++)
         {
             mydofmanager->selectfield(dmfields[i]);
             datafields[i]->synchronize({}, mydofmanager->getselectedfieldorders());
@@ -55,7 +55,7 @@ void rawvec::synchronize(void)
     if (isvaluesynchronizingallowed)
     {
         // Transfer the data back to the vector:
-        for (int i = 0; i < datafields.size(); i++)
+        for (size_t i = 0; i < datafields.size(); i++)
             datafields[i]->transferdata(-1, vec(shared_from_this())|field(dmfields[i]), "set");
     }
     
@@ -178,7 +178,7 @@ void rawvec::updateconstraints(std::shared_ptr<rawfield> constrainedfield, std::
     std::vector<std::shared_ptr<integration>> fieldconstraints = constrainedfield->getconstraints();
 
     // Loop on all disjoint regions:
-    for (int d = 0; d < disjregs.size(); d++)
+    for (size_t d = 0; d < disjregs.size(); d++)
     {
         int disjreg = disjregs[d];
 
@@ -201,7 +201,7 @@ void rawvec::updateconstraints(std::shared_ptr<rawfield> constrainedfield, std::
 
             // Loop on all disjoint regions who share the same constraint-computation-formulation:
             std::shared_ptr<integration> currentconstraint = fieldconstraints[disjreg];
-            for (int i = d; i < disjregs.size(); i++)
+            for (size_t i = d; i < disjregs.size(); i++)
             {
                 if (mydofmanager->isdefined(disjregs[i], 0) && fieldconstraints[disjregs[i]] == currentconstraint)
                 {

--- a/src/formulation/vec.cpp
+++ b/src/formulation/vec.cpp
@@ -37,8 +37,8 @@ void vec::permute(intdensematrix rowpermute, bool invertit)
         VecPermute(getpetsc(), rowpermutis, PETSC_TRUE);
 }
 
-void vec::removeconstraints(void) { errorifpointerisnull(); rawvecptr->removeconstraints(); };
-        
+void vec::removeconstraints(void) { errorifpointerisnull(); rawvecptr->removeconstraints(); }
+
 void vec::updateconstraints(void)
 {
     errorifpointerisnull();
@@ -48,7 +48,7 @@ void vec::updateconstraints(void)
        std::iota(disjregs.begin(), disjregs.end(), 0);
     
     std::vector<std::shared_ptr<rawfield>> fieldsindofmanager = rawvecptr->getdofmanager()->getfields();
-    for (int i = 0; i < fieldsindofmanager.size(); i++)
+    for (size_t i = 0; i < fieldsindofmanager.size(); i++)
         rawvecptr->updateconstraints(fieldsindofmanager[i], disjregs);
         
     // Update the conditional constraints:
@@ -92,7 +92,7 @@ void vec::setdata(void)
     errorifpointerisnull();
     
     std::vector<std::shared_ptr<rawfield>> rfs = rawvecptr->getdofmanager()->getfields();
-    for (int i = 0; i < rfs.size(); i++)
+    for (size_t i = 0; i < rfs.size(); i++)
         rfs[i]->transferdata(-1, vectorfieldselect(rawvecptr, rfs[i]), "set");
 }
 

--- a/src/gausspoint/gphexahedron.h
+++ b/src/gausspoint/gphexahedron.h
@@ -15,6 +15,6 @@
 namespace gphexahedron
 {   
     void set(int integrationorder, std::vector<double>& coordinates, std::vector<double>& weights);
-};
+}
 
 #endif

--- a/src/gausspoint/gpline.h
+++ b/src/gausspoint/gpline.h
@@ -15,6 +15,6 @@
 namespace gpline
 {   
     void set(int integrationorder, std::vector<double>& coordinates, std::vector<double>& weights);
-};
+}
 
 #endif

--- a/src/gausspoint/gppoint.h
+++ b/src/gausspoint/gppoint.h
@@ -15,6 +15,6 @@
 namespace gppoint
 {   
     void set(int integrationorder, std::vector<double>& coordinates, std::vector<double>& weights);
-};
+}
 
 #endif

--- a/src/gausspoint/gpprism.h
+++ b/src/gausspoint/gpprism.h
@@ -15,6 +15,6 @@
 namespace gpprism
 {   
     void set(int integrationorder, std::vector<double>& coordinates, std::vector<double>& weights);
-};
+}
 
 #endif

--- a/src/gausspoint/gppyramid.h
+++ b/src/gausspoint/gppyramid.h
@@ -15,6 +15,6 @@
 namespace gppyramid
 {   
     void set(int integrationorder, std::vector<double>& coordinates, std::vector<double>& weights);
-};
+}
 
 #endif

--- a/src/gausspoint/gpquadrangle.h
+++ b/src/gausspoint/gpquadrangle.h
@@ -15,6 +15,6 @@
 namespace gpquadrangle
 {   
     void set(int integrationorder, std::vector<double>& coordinates, std::vector<double>& weights);
-};
+}
 
 #endif

--- a/src/gausspoint/gptetrahedron.h
+++ b/src/gausspoint/gptetrahedron.h
@@ -15,6 +15,6 @@
 namespace gptetrahedron
 {   
     void set(int integrationorder, std::vector<double>& coordinates, std::vector<double>& weights);
-};
+}
 
 #endif

--- a/src/gausspoint/gptriangle.h
+++ b/src/gausspoint/gptriangle.h
@@ -15,6 +15,6 @@
 namespace gptriangle
 {   
     void set(int integrationorder, std::vector<double>& coordinates, std::vector<double>& weights);
-};
+}
 
 #endif

--- a/src/geometry/geotools.cpp
+++ b/src/geometry/geotools.cpp
@@ -172,7 +172,7 @@ std::vector<std::shared_ptr<rawshape>> geotools::orient(std::vector<std::shared_
     else
         prevnodecoord = p3coord;
 
-    for (int i = 2; i < input.size(); i++)
+    for (size_t i = 2; i < input.size(); i++)
     {
         // Get the coordinates of the points in the current line:
         std::vector<double> p1c = *(input[i]->getsons()[0]->getcoords());
@@ -193,7 +193,7 @@ std::vector<std::shared_ptr<rawshape>> geotools::orient(std::vector<std::shared_
 
 
     // Flip the lines that must be flipped:
-    for (int i = 0; i < input.size(); i++)
+    for (size_t i = 0; i < input.size(); i++)
     {
         if (flipline[i] == true)
             input[i]->flip();
@@ -206,7 +206,7 @@ std::vector< std::shared_ptr<rawshape> > geotools::getrawshapes(std::vector<shap
 {
     std::vector< std::shared_ptr<rawshape> > rawshapes(shapes.size());
 
-    for (int i = 0; i < shapes.size(); i++)
+    for (size_t i = 0; i < shapes.size(); i++)
     {
         std::shared_ptr<rawshape> currentrawshapeptr = shapes[i].getpointer();
 
@@ -226,7 +226,7 @@ std::vector<shape> geotools::getshapes(std::vector< std::shared_ptr<rawshape> > 
 {
     std::vector<shape> shapes(rawshapes.size());
 
-    for (int i = 0; i < rawshapes.size(); i++)
+    for (size_t i = 0; i < rawshapes.size(); i++)
         shapes[i] = shape(rawshapes[i]);
     
     return shapes;
@@ -235,7 +235,7 @@ std::vector<shape> geotools::getshapes(std::vector< std::shared_ptr<rawshape> > 
 std::vector<rawshape*> geotools::getpointers(std::vector< std::shared_ptr<rawshape> > sharedptrs)
 {
     std::vector<rawshape*> output(sharedptrs.size());
-    for (int i = 0; i < output.size(); i++)
+    for (size_t i = 0; i < output.size(); i++)
         output[i] = sharedptrs[i].get();
 
     return output;
@@ -245,7 +245,7 @@ std::vector< std::shared_ptr<rawshape> > geotools::flip(std::vector< std::shared
 {
     std::vector< std::shared_ptr<rawshape> > output(input.size());
 
-    for (int i = 0; i < input.size(); i++)
+    for (size_t i = 0; i < input.size(); i++)
         output[i] = input[input.size()-1-i];    
 
     return output;
@@ -263,7 +263,7 @@ std::vector<std::shared_ptr<rawshape>> geotools::duplicate(std::vector<std::shar
 {
     std::vector<std::shared_ptr<rawshape>> output(input.size());
 
-    for (int i = 0; i < input.size(); i++)
+    for (size_t i = 0; i < input.size(); i++)
         output[i] = input[i]->duplicate();
 
     return output;
@@ -272,16 +272,16 @@ std::vector<std::shared_ptr<rawshape>> geotools::duplicate(std::vector<std::shar
 std::vector<std::shared_ptr<rawshape>> geotools::concatenate(std::vector<std::vector<std::shared_ptr<rawshape>>> input)
 {
     // Compute the total number of rawshapes:
-    int numrawshapes = 0;
-    for (int i = 0; i < input.size(); i++)
+    size_t numrawshapes = 0;
+    for (size_t i = 0; i < input.size(); i++)
         numrawshapes += input[i].size();
 
     std::vector<std::shared_ptr<rawshape>> output(numrawshapes);
 
-    int index = 0;
-    for (int i = 0; i < input.size(); i++)
+    size_t index = 0;
+    for (size_t i = 0; i < input.size(); i++)
     {
-        for (int j = 0; j < input[i].size(); j++)
+        for (size_t j = 0; j < input[i].size(); j++)
         {
             output[index] = input[i][j];
             index++;
@@ -315,21 +315,21 @@ std::vector<double> geotools::appendcoords(std::vector<std::shared_ptr<rawshape>
 {
     std::vector< std::vector<double>* > coordsptrs(rawshapes.size());
 
-    for (int i = 0; i < rawshapes.size(); i++)
+    for (size_t i = 0; i < rawshapes.size(); i++)
         coordsptrs[i] = rawshapes[i]->getcoords();
     
 
     // First calculate the total size:
-    int totallen = 0;
-    for (int i = 0; i < coordsptrs.size(); i++)
+    size_t totallen = 0;
+    for (size_t i = 0; i < coordsptrs.size(); i++)
         totallen += coordsptrs[i]->size();
 
     std::vector<double> output(totallen);
 
-    int index = 0;
-    for (int i = 0; i < coordsptrs.size(); i++)
+    size_t index = 0;
+    for (size_t i = 0; i < coordsptrs.size(); i++)
     {
-        for (int j = 0; j < coordsptrs[i]->size(); j++)
+        for (size_t j = 0; j < coordsptrs[i]->size(); j++)
         {
             output[index] = coordsptrs[i]->at(j);
             index++;
@@ -342,7 +342,7 @@ std::vector<std::vector<int>> geotools::appendelems(std::vector<std::shared_ptr<
 {
     std::vector< std::vector<std::vector<int>>* > elemsptrs(rawshapes.size());
 
-    for (int i = 0; i < rawshapes.size(); i++)
+    for (size_t i = 0; i < rawshapes.size(); i++)
         elemsptrs[i] = rawshapes[i]->getelems();
     
 
@@ -352,16 +352,16 @@ std::vector<std::vector<int>> geotools::appendelems(std::vector<std::shared_ptr<
     for (int e = 0; e < 8; e++)
     {
         // First calculate the total size:
-        int totallen = 0;
-        for (int i = 0; i < elemsptrs.size(); i++)
+        size_t totallen = 0;
+        for (size_t i = 0; i < elemsptrs.size(); i++)
             totallen += elemsptrs[i]->at(e).size();
 
         output[e] = std::vector<int>(totallen);
 
         int index = 0, nodenumshift = 0;
-        for (int i = 0; i < elemsptrs.size(); i++)
+        for (size_t i = 0; i < elemsptrs.size(); i++)
         {
-            for (int j = 0; j < elemsptrs[i]->at(e).size(); j++)
+            for (size_t j = 0; j < elemsptrs[i]->at(e).size(); j++)
             {
                 output[e][index] = elemsptrs[i]->at(e)[j] + nodenumshift;
                 index++;

--- a/src/geometry/geotools.h
+++ b/src/geometry/geotools.h
@@ -73,6 +73,6 @@ namespace geotools
     std::vector<double> appendcoords(std::vector<std::shared_ptr<rawshape>> rawshapes);
     // Append the elements of multiple rawshapes:
     std::vector<std::vector<int>> appendelems(std::vector<std::shared_ptr<rawshape>> rawshapes);
-};
+}
 
 #endif

--- a/src/geometry/rawextrusion.cpp
+++ b/src/geometry/rawextrusion.cpp
@@ -220,10 +220,10 @@ void rawextrusion::mesh(void)
         std::vector<std::shared_ptr<rawshape>> contourfaces(contourlines.size());
 
         std::vector<std::shared_ptr<rawshape>> verticallines(contourlines.size());
-        for (int i = 0; i < contourlines.size(); i++)
+        for (size_t i = 0; i < contourlines.size(); i++)
             verticallines[i] = std::shared_ptr<rawline>(new rawline(-1, {contourlines[i]->getsons()[0], topcontourlines[i]->getsons()[0]}, mynumlayers));
         
-        for (int i = 0; i < contourfaces.size(); i++)
+        for (size_t i = 0; i < contourfaces.size(); i++)
             contourfaces[i] = std::shared_ptr<rawquadrangle>(new rawquadrangle(-1, {contourlines[i], verticallines[(i+1)%verticallines.size()], topcontourlines[i], verticallines[i]}));
 
         sons = geotools::concatenate({{mybaseshape}, contourfaces, {topface}});

--- a/src/geometry/rawshape.cpp
+++ b/src/geometry/rawshape.cpp
@@ -35,7 +35,7 @@ void rawshape::move(expression xmove, expression ymove, expression zmove, bool r
     if (recursively)
     {
         std::vector<rawshape*> subshapes = geotools::unique(geotools::getpointers(getsubshapesrecursively()));
-        for (int i = 0; i < subshapes.size(); i++)
+        for (size_t i = 0; i < subshapes.size(); i++)
             subshapes[i]->move(xmove, ymove, zmove, false);
     }
 }
@@ -58,7 +58,7 @@ void rawshape::shift(double shiftx, double shifty, double shiftz, bool recursive
     if (recursively)
     {
         std::vector<rawshape*> subshapes = geotools::unique(geotools::getpointers(getsubshapesrecursively()));
-        for (int i = 0; i < subshapes.size(); i++)
+        for (size_t i = 0; i < subshapes.size(); i++)
             subshapes[i]->shift(shiftx, shifty, shiftz, false);
     }
 }
@@ -81,7 +81,7 @@ void rawshape::scale(double scalex, double scaley, double scalez, bool recursive
     if (recursively)
     {
         std::vector<rawshape*> subshapes = geotools::unique(geotools::getpointers(getsubshapesrecursively()));
-        for (int i = 0; i < subshapes.size(); i++)
+        for (size_t i = 0; i < subshapes.size(); i++)
             subshapes[i]->scale(scalex, scaley, scalez, false);
     }
 }
@@ -98,7 +98,7 @@ void rawshape::rotate(double alphax, double alphay, double alphaz, bool recursiv
     if (recursively)
     {
         std::vector<rawshape*> subshapes = geotools::unique(geotools::getpointers(getsubshapesrecursively()));
-        for (int i = 0; i < subshapes.size(); i++)
+        for (size_t i = 0; i < subshapes.size(); i++)
             subshapes[i]->rotate(alphax, alphay, alphaz, false);
     }
 }
@@ -159,13 +159,13 @@ std::vector<std::shared_ptr<rawshape>> rawshape::getsubshapesrecursively(void)
     std::vector<std::shared_ptr<rawshape>> subshapes = getsubshapes();
 
     int index = 0;
-    for (int i = 0; i < subshapes.size(); i++)
+    for (size_t i = 0; i < subshapes.size(); i++)
     {
         output[index] = subshapes[i];
         index++;
 
         std::vector<std::shared_ptr<rawshape>> toappend = subshapes[i]->getsubshapesrecursively();
-        for (int j = 0; j < toappend.size(); j++)
+        for (size_t j = 0; j < toappend.size(); j++)
             output[index+j] = toappend[j];
         index += toappend.size();
     }
@@ -212,7 +212,7 @@ int rawshape::countsubshapesrecursively(void)
 
     int numsubshapes = subshapes.size();
 
-    for (int i = 0; i < subshapes.size(); i++)
+    for (size_t i = 0; i < subshapes.size(); i++)
         numsubshapes += subshapes[i]->countsubshapesrecursively();
 
     return numsubshapes;
@@ -236,7 +236,7 @@ void rawshape::replicatelinks(std::shared_ptr<rawshape> origin)
     std::vector<std::shared_ptr<rawshape>> linkedsubshapes(reorderingvector.size());
 
     linkedsubshapes[reorderingvector[0]] = subshapes[reorderingvector[0]];
-    for (int i = 1; i < reorderingvector.size(); i++)
+    for (size_t i = 1; i < reorderingvector.size(); i++)
     {
         if (originsubshapes[reorderingvector[i]] != originsubshapes[reorderingvector[i-1]])
             linkedsubshapes[reorderingvector[i]] = subshapes[reorderingvector[i]];

--- a/src/geometry/rawunion.cpp
+++ b/src/geometry/rawunion.cpp
@@ -12,7 +12,7 @@ rawunion::rawunion(int physreg, std::vector<std::shared_ptr<rawshape>> input)
     }
     
     int mydimension = input[0]->getdimension();
-    for (int i = 1; i < input.size(); i++)
+    for (size_t i = 1; i < input.size(); i++)
     {
         if (input[i]->getdimension() != mydimension)
         {
@@ -29,7 +29,7 @@ rawunion::rawunion(int physreg, std::vector<std::shared_ptr<rawshape>> input)
 std::shared_ptr<rawshape> rawunion::extrude(int physreg, double height, int numlayers, std::vector<double> extrudedirection)
 {
     std::vector<std::shared_ptr<rawshape>> extrudedshapes(sons.size());
-    for (int i = 0; i < sons.size(); i++)
+    for (size_t i = 0; i < sons.size(); i++)
         extrudedshapes[i] = sons[i]->extrude(physreg, height, numlayers, extrudedirection);
 
     return std::shared_ptr<rawunion>(new rawunion(physreg, extrudedshapes));

--- a/src/harmonic.cpp
+++ b/src/harmonic.cpp
@@ -96,7 +96,7 @@ std::vector<std::pair<int,double>> harmonic::getproduct(int harm1, int harm2, in
     std::vector<std::pair<int,double>> harmsofproduct = getproduct(harm1, newharm2);
 
     // Multiply the coefficient by the extra 2*pi*fi like factor from the time derivation:
-    for (int p = 0; p < harmsofproduct.size(); p++)
+    for (size_t p = 0; p < harmsofproduct.size(); p++)
         harmsofproduct[p].second *= getderivationfactor(harm2timederivativeorder, harm2);
 
     return harmsofproduct;
@@ -131,7 +131,7 @@ std::vector<std::vector<densematrix>> harmonic::timederivative(int timederivativ
     if (timederivativeorder == 0)
         return input;
    
-    for (int h = 0; h < input.size(); h++)
+    for (size_t h = 0; h < input.size(); h++)
     {
         if (input[h].size() == 1)
             input[h][0].multiplyelementwise(getderivationfactor(timederivativeorder, h));
@@ -144,7 +144,7 @@ std::vector<std::vector<densematrix>> harmonic::timederivative(int timederivativ
             input.push_back({});
         
         // Harmonic 1 is zero anyway. Start at 2.
-        for (int h = 2; h < input.size(); h = h+2)
+        for (size_t h = 2; h < input.size(); h = h+2)
         {
             std::vector<densematrix> temp = input[h];
             input[h] = input[h+1];

--- a/src/harmonic.h
+++ b/src/harmonic.h
@@ -37,6 +37,6 @@ namespace harmonic
     double getderivationfactor(int timederivativeorder, int harm);
     // Apply the time derivative to 'input':
     std::vector<std::vector<densematrix>> timederivative(int timederivativeorder, std::vector<std::vector<densematrix>> input);
-};
+}
 
 #endif

--- a/src/intdensematrix.cpp
+++ b/src/intdensematrix.cpp
@@ -119,7 +119,7 @@ std::vector<std::vector<int>> intdensematrix::findalloccurences(int maxintval)
     std::vector<int> numoccurences = countalloccurences(maxintval);
     
     std::vector<std::vector<int>> output(numoccurences.size());
-    for (int i = 0; i < numoccurences.size(); i++)
+    for (size_t i = 0; i < numoccurences.size(); i++)
         output[i] = std::vector<int>(numoccurences[i]);
     
     std::vector<int> indexes(numoccurences.size(), 0);

--- a/src/io/gmsh/gmshinterface.cpp
+++ b/src/io/gmsh/gmshinterface.cpp
@@ -296,7 +296,7 @@ void gmshinterface::writetofile(std::string name, nodes& mynodes, elements& myel
             std::vector<int> alldisjointregions = physicalregionobject->getdisjointregions();
 
             // Iterate on all disjoint regions in the physical region:
-            for (int h = 0; h < alldisjointregions.size(); h++)
+            for (size_t h = 0; h < alldisjointregions.size(); h++)
             {
                 // Get the unique element type in the disjoint region:
                 int typenumber = mydisjointregions.getelementtypenumber(alldisjointregions[h]);
@@ -346,7 +346,7 @@ void gmshinterface::writetofile(std::string name, iodata datatowrite)
     std::vector<int> activeelementtypes = datatowrite.getactiveelementtypes();
     
     // Loop on all active element types:
-    for (int i = 0; i < activeelementtypes.size(); i++)
+    for (size_t i = 0; i < activeelementtypes.size(); i++)
     {
         int elemtypenum = activeelementtypes[i];
         element myelement(elemtypenum);
@@ -510,22 +510,22 @@ void gmshinterface::writeinterpolationscheme(std::string name, std::vector<std::
     {
         posfile << "\nINTERPOLATION_SCHEME";
         
-        for (int m = 0; m < poly.size(); m++)
+        for (size_t m = 0; m < poly.size(); m++)
         {
             posfile << "\n{\n";
             
             // Print the polynomial coefficients:
-            for (int p = 0; p < poly[m].size(); p++)
+            for (size_t p = 0; p < poly[m].size(); p++)
             {
                 posfile << "  {";
 
                 std::vector<std::vector<std::vector<double>>> polyformfunctions = poly[m][p].get();
 
-                for (int i = 0; i < polyformfunctions.size(); i++)
+                for (size_t i = 0; i < polyformfunctions.size(); i++)
                 {
-                    for (int j = 0; j < polyformfunctions[i].size(); j++)
+                    for (size_t j = 0; j < polyformfunctions[i].size(); j++)
                     {
-                        for (int k = 0; k < polyformfunctions[i][j].size(); k++)
+                        for (size_t k = 0; k < polyformfunctions[i][j].size(); k++)
                         {
                             if (i == polyformfunctions.size() - 1 && j == polyformfunctions[i].size() - 1 && k == polyformfunctions[i][j].size() - 1)
                                 posfile << polyformfunctions[i][j][k];
@@ -546,11 +546,11 @@ void gmshinterface::writeinterpolationscheme(std::string name, std::vector<std::
             // Print the list of monomials:
             std::vector<std::vector<std::vector<double>>> polyformfunctions = poly[m][0].get();
 
-            for (int i = 0; i < polyformfunctions.size(); i++)
+            for (size_t i = 0; i < polyformfunctions.size(); i++)
             {
-                for (int j = 0; j < polyformfunctions[i].size(); j++)
+                for (size_t j = 0; j < polyformfunctions[i].size(); j++)
                 {
-                    for (int k = 0; k < polyformfunctions[i][j].size(); k++)
+                    for (size_t k = 0; k < polyformfunctions[i][j].size(); k++)
                     {
                         posfile << "  {" << i << "," << j << "," << k << "}";
                         if (i == polyformfunctions.size() - 1 && j == polyformfunctions[i].size() - 1 && k == polyformfunctions[i][j].size() - 1)

--- a/src/io/gmsh/gmshinterface.h
+++ b/src/io/gmsh/gmshinterface.h
@@ -55,6 +55,6 @@ namespace gmshinterface
     int converttogmshelementtypenumber(int ourtypenumber);
     
     char getelementidentifierinposformat(int ourtypenumber);
-};
+}
 
 #endif

--- a/src/io/iodata.cpp
+++ b/src/io/iodata.cpp
@@ -32,16 +32,16 @@ void iodata::combine(void)
     
         for (int s = 0; s < 3; s++)
             mycoords[s][i] = {densematrix(mycoords[s][i])};
-        for (int comp = 0; comp < mydata.size(); comp++)
+        for (size_t comp = 0; comp < mydata.size(); comp++)
             mydata[comp][i] = {densematrix(mydata[comp][i])};
     }
 }
 
 bool iodata::isscalar(void) { return isscalardata; }
-int iodata::getinterpolorder(void) { return myinterpolorder; };
-int iodata::getgeointerpolorder(void) { return mygeointerpolorder; };
+int iodata::getinterpolorder(void) { return myinterpolorder; }
+int iodata::getgeointerpolorder(void) { return mygeointerpolorder; }
 
-std::vector<double> iodata::gettimetags(void) { return mytimevals; };
+std::vector<double> iodata::gettimetags(void) { return mytimevals; }
 
 bool iodata::ispopulated(int elemtypenum)
 {
@@ -86,7 +86,7 @@ void iodata::adddata(int elemtypenum, std::vector<densematrix> vals)
             vals.push_back(densematrix(vals[0].countrows(), vals[0].countcolumns(), 0.0));
     }
 
-    for (int comp = 0; comp < vals.size(); comp++)
+    for (size_t comp = 0; comp < vals.size(); comp++)
         mydata[comp][elemtypenum].push_back(vals[comp]);
 }
 

--- a/src/io/iointerface.cpp
+++ b/src/io/iointerface.cpp
@@ -96,7 +96,7 @@ void iointerface::write(std::string filename, std::vector<int>& intdata, std::ve
             name << intdata.size() << std::endl << doubledata.size() << std::endl;
 
             // Write the int data to the file:
-            for (int i = 0; i < intdata.size(); i++)
+            for (size_t i = 0; i < intdata.size(); i++)
                 name << intdata[i] << std::endl;
 
             // To write all doubles with enough digits to the file:
@@ -126,9 +126,9 @@ void iointerface::write(std::string filename, std::vector<int>& intdata, std::ve
 
         datavals[0] = intdata.size();
         datavals[1] = doubledata.size();
-        for (int i = 0; i < intdata.size(); i++)
+        for (size_t i = 0; i < intdata.size(); i++)
             datavals[2 + i] = intdata[i];
-        for (int i = 0; i < doubledata.size(); i++)
+        for (size_t i = 0; i < doubledata.size(); i++)
             datavals[2+intdata.size() + i] = doubledata[i];
             
         // Let petsc write the binary file for us:
@@ -168,7 +168,7 @@ void iointerface::load(std::string filename, std::vector<int>& intdata, std::vec
             doubledata.resize(std::stoi(currentline));
 
             // Load the intdata:
-            for (int i = 0; i < intdata.size(); i++)
+            for (size_t i = 0; i < intdata.size(); i++)
             {
                 std::getline(name, currentline);
                 myalgorithm::osclean(currentline);
@@ -176,7 +176,7 @@ void iointerface::load(std::string filename, std::vector<int>& intdata, std::vec
             }
             
             // Load the doubledata:
-            for (int i = 0; i < doubledata.size(); i++)
+            for (size_t i = 0; i < doubledata.size(); i++)
             {
                 std::getline(name, currentline);
                 myalgorithm::osclean(currentline);

--- a/src/io/iointerface.h
+++ b/src/io/iointerface.h
@@ -35,6 +35,6 @@ namespace iointerface
     
     // Read first an int vector then a double vector from ASCII or binary format:
     void load(std::string filename, std::vector<int>& intdata, std::vector<double>& doubledata, bool isbinary);
-};
+}
 
 #endif

--- a/src/io/nastran/nasdataline.cpp
+++ b/src/io/nastran/nasdataline.cpp
@@ -85,7 +85,7 @@ bool nasdataline::addline(std::string linetoadd)
             
             vertices.resize(eleminfo[1]);
             
-            for (int i = 0; i < vertices.size(); i++)
+            for (size_t i = 0; i < vertices.size(); i++)
             {
                 std::string curstrng = linetoadd.substr(24+8*i,8);
                 if (curstrng[0] == '+')
@@ -110,7 +110,7 @@ bool nasdataline::addline(std::string linetoadd)
             
             vertices.resize(eleminfo[1]);
 
-            for (int i = 0; i < vertices.size(); i++)
+            for (size_t i = 0; i < vertices.size(); i++)
             {
                 std::string curstrng = curline.getstringtonextcomma();
                 if (curstrng[0] == '+')

--- a/src/io/nastran/nastraninterface.cpp
+++ b/src/io/nastran/nastraninterface.cpp
@@ -48,7 +48,7 @@ void nastraninterface::readfromfile(std::string name, nodes& mynodes, elements& 
         mynodes.setnumber(nodecoords.size());
         std::vector<double>* nodecoordinates = mynodes.getcoordinates();
         
-        for (int i = 0; i < nodecoords.size(); i++)
+        for (size_t i = 0; i < nodecoords.size(); i++)
         {
             nodecoordinates->at(3*i+0) = nodecoords[i][0];
             nodecoordinates->at(3*i+1) = nodecoords[i][1];

--- a/src/io/nastran/nastraninterface.h
+++ b/src/io/nastran/nastraninterface.h
@@ -22,6 +22,6 @@ namespace nastraninterface
 {
     // Load the mesh to the 'nodes', 'elements' and 'physicalregions' objects.
     void readfromfile(std::string name, nodes&, elements&, physicalregions&);
-};
+}
 
 #endif

--- a/src/io/paraview/pvinterface.cpp
+++ b/src/io/paraview/pvinterface.cpp
@@ -12,7 +12,7 @@ void pvinterface::writetovtkfile(std::string name, iodata datatowrite)
     if (timetags.size() == 0)
         writetovtkfile(name, datatowrite, -1);
 
-    for (int i = 0; i < timetags.size(); i++)
+    for (size_t i = 0; i < timetags.size(); i++)
     {
         std::string curname = namenoext + "_" + std::to_string(i) + ".vtk";
         writetovtkfile(curname, datatowrite, i);
@@ -30,7 +30,7 @@ void pvinterface::writetovtufile(std::string name, iodata datatowrite)
     if (timetags.size() == 0)
         writetovtufile(name, datatowrite, -1);
 
-    for (int i = 0; i < timetags.size(); i++)
+    for (size_t i = 0; i < timetags.size(); i++)
     {
         std::string curname = namenoext + "_" + std::to_string(i) + ".vtu";
         writetovtufile(curname, datatowrite, i);

--- a/src/io/paraview/pvinterface.h
+++ b/src/io/paraview/pvinterface.h
@@ -34,6 +34,6 @@ namespace pvinterface
     int converttoparaviewelementtypenumber(int ourtypenumber);
     // ParaView comes with its own element node ordering:
     std::vector<int> getnodereordering(int ourtypenumber);
-};
+}
 
 #endif

--- a/src/mesh/disjointregions.cpp
+++ b/src/mesh/disjointregions.cpp
@@ -70,7 +70,7 @@ std::vector<int> disjointregions::getindim(int dim)
 {
     std::vector<int> output(elementtypenumbers.size());
     int num = 0;
-    for (int d = 0; d < output.size(); d++)
+    for (size_t d = 0; d < output.size(); d++)
     {
         if (getelementdimension(d) == dim)
         {
@@ -87,7 +87,7 @@ std::vector<int> disjointregions::getintype(int elementtypenumber)
 {
     std::vector<int> output(elementtypenumbers.size());
     int num = 0;
-    for (int d = 0; d < output.size(); d++)
+    for (size_t d = 0; d < output.size(); d++)
     {
         if (getelementtypenumber(d) == elementtypenumber)
         {
@@ -107,15 +107,15 @@ bool disjointregions::isinphysicalregion(int disjointregionnumber, int physicalr
 
 void disjointregions::removephysicalregions(std::vector<bool> istoremove)
 {
-    for (int i = 0; i < disjointregionsdefinition.size(); i++)
+    for (size_t i = 0; i < disjointregionsdefinition.size(); i++)
     {
-        int index = 0;
-        for (int j = 0; j < disjointregionsdefinition[i].size(); j++)
+        size_t index = 0;
+        for (size_t j = 0; j < disjointregionsdefinition[i].size(); j++)
         {
             if (not(istoremove[j]))
             {
                 disjointregionsdefinition[i][index] = disjointregionsdefinition[i][j];
-                index++;    
+                index++;
             }
         }
         disjointregionsdefinition[i].resize(index);

--- a/src/mesh/disjointregionselector.cpp
+++ b/src/mesh/disjointregionselector.cpp
@@ -5,7 +5,7 @@ disjointregionselector::disjointregionselector(std::vector<int> disjointregionnu
 {
     // Get the element type number in every disjoint region:
     std::vector<int> typenums(disjointregionnumbers.size());
-    for (int i = 0; i < disjointregionnumbers.size(); i++)
+    for (size_t i = 0; i < disjointregionnumbers.size(); i++)
         typenums[i] = (universe::mymesh->getdisjointregions())->getelementtypenumber(disjointregionnumbers[i]);
     criteria.push_back(typenums);
     
@@ -15,7 +15,7 @@ disjointregionselector::disjointregionselector(std::vector<int> disjointregionnu
     // The < operator is overloaded by a lambda function.
     std::sort(renumberingvector.begin(), renumberingvector.end(), [&](int elem1, int elem2)
     { 
-        for (int i = 0; i < criteria.size(); i++)
+        for (size_t i = 0; i < criteria.size(); i++)
         {
             if (criteria[i][elem1] < criteria[i][elem2])
                 return true;
@@ -28,18 +28,18 @@ disjointregionselector::disjointregionselector(std::vector<int> disjointregionnu
     
     // Sort all criteria accordingly:
     std::vector<std::vector<int>> criteriabackup = criteria;
-    for (int i = 0; i < criteria.size(); i++)
+    for (size_t i = 0; i < criteria.size(); i++)
     {
-        for (int j = 0; j < criteria[i].size(); j++)
+        for (size_t j = 0; j < criteria[i].size(); j++)
             criteria[i][j] = criteriabackup[i][renumberingvector[j]];
     }        
     
     // Split in groups:
     int currentgroup = -1;
-    for (int i = 0; i < disjointregionnumbers.size(); i++)
+    for (size_t i = 0; i < disjointregionnumbers.size(); i++)
     {
         bool newgroup = false;
-        for (int j = 0; j < criteria.size(); j++)
+        for (size_t j = 0; j < criteria.size(); j++)
             newgroup = newgroup || i == 0 || criteria[j][i] != criteria[j][i-1];
         
         if (newgroup)

--- a/src/mesh/elements.cpp
+++ b/src/mesh/elements.cpp
@@ -315,11 +315,11 @@ void elements::getrefcoordsondisjregs(int origintype, std::vector<int>& elems, s
 {
     std::vector<int> renumtoelems(count(origintype), -1);
     std::vector<bool> isprocessed(elems.size(), false);
-    for (int i = 0; i < elems.size(); i++)
+    for (size_t i = 0; i < elems.size(); i++)
         renumtoelems[elems[i]] = i;
 
-    int numrc = refcoords.size()/3;
-    int numpoints = elems.size() * numrc;
+    size_t numrc = refcoords.size()/3;
+    size_t numpoints = elems.size() * numrc;
     element mysubelement(origintype);
     int subnumnodes = mysubelement.countnodes();
     std::vector<double> cornerrcs(3*subnumnodes);
@@ -329,7 +329,7 @@ void elements::getrefcoordsondisjregs(int origintype, std::vector<int>& elems, s
     
     std::vector<int> nodeindexincurelem(count(0));
 
-    for (int i = 0; i < targetdisjregs.size(); i++)
+    for (size_t i = 0; i < targetdisjregs.size(); i++)
     {
         int d = targetdisjregs[i];
         int tn = mydisjointregions->getelementtypenumber(d);
@@ -370,7 +370,7 @@ void elements::getrefcoordsondisjregs(int origintype, std::vector<int>& elems, s
                         
                     std::vector<double> rcsintarget = mysubelement.calculatecoordinates(refcoords, cornerrcs, 0, (origintype == 0));
                     
-                    for (int r = 0; r < numrc; r++)
+                    for (size_t r = 0; r < numrc; r++)
                     {
                         targetelems[2*origindex*numrc+2*r+0] = tn;
                         targetelems[2*origindex*numrc+2*r+1] = rb+e;
@@ -411,7 +411,7 @@ std::vector<double>* elements::getsphereradius(int elementtypenumber)
             std::vector<double> ynodes = getnodecoordinates(elementtypenumber, i, 1);
             std::vector<double> znodes = getnodecoordinates(elementtypenumber, i, 2);
             
-            for (int j = 0; j < xnodes.size(); j++)
+            for (size_t j = 0; j < xnodes.size(); j++)
             {
                 double curdist = std::sqrt( std::pow(mybarys->at(3*i+0)-xnodes[j], 2) + std::pow(mybarys->at(3*i+1)-ynodes[j], 2) + std::pow(mybarys->at(3*i+2)-znodes[j], 2) );
                 if (curdist > maxdist)
@@ -441,7 +441,7 @@ std::vector<double>* elements::getboxdimensions(int elementtypenumber)
                 std::vector<double> curnodescoords = getnodecoordinates(elementtypenumber, i, c);
                 
                 double maxdist = 0;
-                for (int j = 0; j < curnodescoords.size(); j++)
+                for (size_t j = 0; j < curnodescoords.size(); j++)
                 {
                     double curdist = std::abs(mybarys->at(3*i+c)-curnodescoords[j]);
                     if (curdist > maxdist)
@@ -510,7 +510,7 @@ void elements::printsubelements(void)
         if (subelementsinelements[elementtypenumber][0].size() != 0)
         {
             std::cout << "Points in " << myelement.gettypenameconjugation(2) << ":" << std::endl;
-            for (int i = 0; i < subelementsinelements[elementtypenumber][0].size()/myelement.countcurvednodes(); i++)
+            for (size_t i = 0; i < subelementsinelements[elementtypenumber][0].size()/myelement.countcurvednodes(); i++)
             {
                 std::cout << std::left << std::setw(8) << i << " ";
                 for (int j = 0; j < myelement.countcurvednodes(); j++)
@@ -522,7 +522,7 @@ void elements::printsubelements(void)
         if (subelementsinelements[elementtypenumber][1].size() != 0)
         {
             std::cout << "Lines in " << myelement.gettypenameconjugation(2) << ":" << std::endl;
-            for (int i = 0; i < subelementsinelements[elementtypenumber][1].size()/myelement.countedges(); i++)
+            for (size_t i = 0; i < subelementsinelements[elementtypenumber][1].size()/myelement.countedges(); i++)
             {
                 std::cout << std::left << std::setw(8) << i << " ";
                 for (int j = 0; j < myelement.countedges(); j++)
@@ -534,7 +534,7 @@ void elements::printsubelements(void)
         if (subelementsinelements[elementtypenumber][2].size() != 0)
         {
             std::cout << "Triangles in " << myelement.gettypenameconjugation(2) << ":" << std::endl;
-            for (int i = 0; i < subelementsinelements[elementtypenumber][2].size()/myelement.counttriangularfaces(); i++)
+            for (size_t i = 0; i < subelementsinelements[elementtypenumber][2].size()/myelement.counttriangularfaces(); i++)
             {
                 std::cout << std::left << std::setw(8) << i << " ";
                 for (int j = 0; j < myelement.counttriangularfaces(); j++)
@@ -546,7 +546,7 @@ void elements::printsubelements(void)
         if (subelementsinelements[elementtypenumber][3].size() != 0)
         {
             std::cout << "Quadrangles in " << myelement.gettypenameconjugation(2) << ":" << std::endl;
-            for (int i = 0; i < subelementsinelements[elementtypenumber][3].size()/myelement.countquadrangularfaces(); i++)
+            for (size_t i = 0; i < subelementsinelements[elementtypenumber][3].size()/myelement.countquadrangularfaces(); i++)
             {
                 std::cout << std::left << std::setw(8) << i << " ";
                 for (int j = 0; j < myelement.countquadrangularfaces(); j++)
@@ -569,7 +569,7 @@ void elements::printtotalorientations(void)
         element myelement(elementtypenumber);
         std::cout << "Total orientations for all " << myelement.gettypenameconjugation(2) << ":" << std::endl;
         
-        for (int i = 0; i < totalorientations[elementtypenumber].size(); i++)
+        for (size_t i = 0; i < totalorientations[elementtypenumber].size(); i++)
             std::cout << std::left << std::setw(12) << i << std::left << std::setw(12) << totalorientations[elementtypenumber][i] << std::endl;
     }
     std::cout << std::endl;
@@ -671,7 +671,7 @@ std::vector<int> elements::removeduplicates(int elementtypenumber)
     std::vector<int> elementrenumbering;
     int numberofnonduplicates = myalgorithm::removeduplicates(barycentercoordinates, elementrenumbering);
     
-    for (int i = 0; i < elementrenumbering.size(); i++)
+    for (size_t i = 0; i < elementrenumbering.size(); i++)
     {
         if (elementrenumbering[i] != i)
         {
@@ -717,22 +717,22 @@ void elements::renumber(int elementtypenumber, std::vector<int>& renumberingvect
         {
             // Renumber the point elements (i.e. the nodes):
             case 0:
-                for (int i = 0; i < subelementsinelements[typenum][0].size(); i++)
+                for (size_t i = 0; i < subelementsinelements[typenum][0].size(); i++)
                     subelementsinelements[typenum][0][i] = renumberingvector[subelementsinelements[typenum][0][i]];
                 break;
             // Renumber the line elements:
             case 1:
-                for (int i = 0; i < subelementsinelements[typenum][1].size(); i++)
+                for (size_t i = 0; i < subelementsinelements[typenum][1].size(); i++)
                     subelementsinelements[typenum][1][i] = renumberingvector[subelementsinelements[typenum][1][i]];
                 break;
             // Renumber the triangle elements:
             case 2:
-                for (int i = 0; i < subelementsinelements[typenum][2].size(); i++)
+                for (size_t i = 0; i < subelementsinelements[typenum][2].size(); i++)
                     subelementsinelements[typenum][2][i] = renumberingvector[subelementsinelements[typenum][2][i]];
                 break;
             // Renumber the quadrangle elements:
             case 3:
-                for (int i = 0; i < subelementsinelements[typenum][3].size(); i++)
+                for (size_t i = 0; i < subelementsinelements[typenum][3].size(); i++)
                     subelementsinelements[typenum][3][i] = renumberingvector[subelementsinelements[typenum][3][i]];
                 break;
         }
@@ -752,13 +752,13 @@ void elements::reorder(int elementtypenumber, std::vector<int> &elementreorderin
         int numberofquadrangles = numberofsubelementsineveryelement[elementtypenumber][3];
         
         std::vector<int> pointsinelementspart = subelementsinelements[elementtypenumber][0];
-        for (int i = 0; i < subelementsinelements[elementtypenumber][0].size()/numberofnodes; i++)
+        for (size_t i = 0; i < subelementsinelements[elementtypenumber][0].size()/numberofnodes; i++)
         {
             for (int j = 0; j < numberofnodes; j++)
                 subelementsinelements[elementtypenumber][0][numberofnodes*i+j] = pointsinelementspart[numberofnodes*elementreordering[i]+j]; 
         }
         std::vector<int> linesinelementspart = subelementsinelements[elementtypenumber][1];
-        for (int i = 0; i < subelementsinelements[elementtypenumber][1].size()/numberoflines; i++)
+        for (size_t i = 0; i < subelementsinelements[elementtypenumber][1].size()/numberoflines; i++)
         {
             for (int j = 0; j < numberoflines; j++)
                 subelementsinelements[elementtypenumber][1][numberoflines*i+j] = linesinelementspart[numberoflines*elementreordering[i]+j]; 
@@ -766,7 +766,7 @@ void elements::reorder(int elementtypenumber, std::vector<int> &elementreorderin
         if (numberoftriangles != 0)
         {
             std::vector<int> trianglesinelementspart = subelementsinelements[elementtypenumber][2];
-            for (int i = 0; i < subelementsinelements[elementtypenumber][2].size()/numberoftriangles; i++)
+            for (size_t i = 0; i < subelementsinelements[elementtypenumber][2].size()/numberoftriangles; i++)
             {
                 for (int j = 0; j < numberoftriangles; j++)
                     subelementsinelements[elementtypenumber][2][numberoftriangles*i+j] = trianglesinelementspart[numberoftriangles*elementreordering[i]+j]; 
@@ -775,7 +775,7 @@ void elements::reorder(int elementtypenumber, std::vector<int> &elementreorderin
         if (numberofquadrangles != 0)
         {
             std::vector<int> quadranglesinelementspart = subelementsinelements[elementtypenumber][3];
-            for (int i = 0; i < subelementsinelements[elementtypenumber][3].size()/numberofquadrangles; i++)
+            for (size_t i = 0; i < subelementsinelements[elementtypenumber][3].size()/numberofquadrangles; i++)
             {
                 for (int j = 0; j < numberofquadrangles; j++)
                     subelementsinelements[elementtypenumber][3][numberofquadrangles*i+j] = quadranglesinelementspart[numberofquadrangles*elementreordering[i]+j]; 
@@ -785,15 +785,15 @@ void elements::reorder(int elementtypenumber, std::vector<int> &elementreorderin
     
     
     std::vector<int> indisjointregionpart = indisjointregion[elementtypenumber];
-    for (int i = 0; i < indisjointregion[elementtypenumber].size(); i++)
+    for (size_t i = 0; i < indisjointregion[elementtypenumber].size(); i++)
         indisjointregion[elementtypenumber][i] = indisjointregionpart[elementreordering[i]];
 
     std::vector<int> totalorientationspart = totalorientations[elementtypenumber];
-    for (int i = 0; i < totalorientations[elementtypenumber].size(); i++)
+    for (size_t i = 0; i < totalorientations[elementtypenumber].size(); i++)
         totalorientations[elementtypenumber][i] = totalorientationspart[elementreordering[i]];
 
     std::vector<double> barycenterspart = barycenters[elementtypenumber];
-    for (int i = 0; i < barycenters[elementtypenumber].size()/3; i++)
+    for (size_t i = 0; i < barycenters[elementtypenumber].size()/3; i++)
     {
         barycenters[elementtypenumber][3*i+0] = barycenterspart[3*elementreordering[i]+0];
         barycenters[elementtypenumber][3*i+1] = barycenterspart[3*elementreordering[i]+1];
@@ -801,11 +801,11 @@ void elements::reorder(int elementtypenumber, std::vector<int> &elementreorderin
     }
     
     std::vector<double> sphereradiuspart = sphereradius[elementtypenumber];
-    for (int i = 0; i < sphereradius[elementtypenumber].size(); i++)
+    for (size_t i = 0; i < sphereradius[elementtypenumber].size(); i++)
         sphereradius[elementtypenumber][i] = sphereradiuspart[elementreordering[i]];
     
     std::vector<double> boxdimensionspart = boxdimensions[elementtypenumber];
-    for (int i = 0; i < boxdimensions[elementtypenumber].size()/3; i++)
+    for (size_t i = 0; i < boxdimensions[elementtypenumber].size()/3; i++)
     {
         boxdimensions[elementtypenumber][3*i+0] = boxdimensionspart[3*elementreordering[i]+0];
         boxdimensions[elementtypenumber][3*i+1] = boxdimensionspart[3*elementreordering[i]+1];
@@ -935,7 +935,7 @@ void elements::definedisjointregions(void)
         for (int typenum = 0; typenum <= 7; typenum++)
         {
             // Iterate on all elements of the given type:
-            for (int i = 0; i < (*elementsinphysicalregion)[typenum].size(); i++)
+            for (size_t i = 0; i < (*elementsinphysicalregion)[typenum].size(); i++)
                 isinphysicalregion[typenum][(*elementsinphysicalregion)[typenum][i] * numberofphysicalregions + physregindex] = true;
         }
     }
@@ -949,7 +949,7 @@ void elements::definedisjointregions(void)
         int numberoftriangles = numberofsubelementsineveryelement[typenum][2];
         int numberofquadrangles = numberofsubelementsineveryelement[typenum][3];
 
-        for (int elem = 0; elem < subelementsinelements[typenum][0].size()/numberofcurvednodes; elem++)
+        for (size_t elem = 0; elem < subelementsinelements[typenum][0].size()/numberofcurvednodes; elem++)
         {
             for (int i = 0; i < numberofcurvednodes; i++)
             {
@@ -962,7 +962,7 @@ void elements::definedisjointregions(void)
             }
         }
         
-        for (int elem = 0; elem < subelementsinelements[typenum][1].size()/numberoflines; elem++)
+        for (size_t elem = 0; elem < subelementsinelements[typenum][1].size()/numberoflines; elem++)
         {
             for (int i = 0; i < numberoflines; i++)
             {
@@ -977,7 +977,7 @@ void elements::definedisjointregions(void)
 
         if (numberoftriangles != 0)
         {
-            for (int elem = 0; elem < subelementsinelements[typenum][2].size()/numberoftriangles; elem++)
+            for (size_t elem = 0; elem < subelementsinelements[typenum][2].size()/numberoftriangles; elem++)
             {
                 for (int i = 0; i < numberoftriangles; i++)
                 {
@@ -993,7 +993,7 @@ void elements::definedisjointregions(void)
         
         if (numberofquadrangles != 0)
         {
-            for (int elem = 0; elem < subelementsinelements[typenum][3].size()/numberofquadrangles; elem++)
+            for (size_t elem = 0; elem < subelementsinelements[typenum][3].size()/numberofquadrangles; elem++)
             {
                 for (int i = 0; i < numberofquadrangles; i++)
                 {
@@ -1073,7 +1073,7 @@ void elements::definedisjointregionsranges(void)
 {
     for (int typenum = 0; typenum <= 7; typenum++)
     {
-        for (int i = 0; i < indisjointregion[typenum].size(); i++)
+        for (size_t i = 0; i < indisjointregion[typenum].size(); i++)
         {
             if (i == 0)
                 mydisjointregions->setrangebegin(indisjointregion[typenum][i], 0);

--- a/src/mesh/elementselector.cpp
+++ b/src/mesh/elementselector.cpp
@@ -17,7 +17,7 @@ void elementselector::prepare(bool isorientationdependent)
         std::vector<int> elemsbackup = elems;
         std::vector<int> originalindexesbackup = originalindexes;
         
-        for (int i = 0; i < totalorientations.size(); i++)
+        for (size_t i = 0; i < totalorientations.size(); i++)
         {
             totalorientations[i] = totalorientationsbackup[renumberingvector[i]];
             disjointregions[i] = disjointregionsbackup[renumberingvector[i]];
@@ -49,7 +49,7 @@ elementselector::elementselector(std::vector<int> disjointregionnumbers, bool is
 
     // Get the total number of elements in all disjoint regions for preallocation.
     int totalnumberofelements = 0;
-    for (int i = 0; i < mydisjointregionnumbers.size(); i++)
+    for (size_t i = 0; i < mydisjointregionnumbers.size(); i++)
         totalnumberofelements += universe::mymesh->getdisjointregions()->countelements(mydisjointregionnumbers[i]);
     
     // Create 'disjointregions', 'totalorientations' and 'elems':
@@ -61,7 +61,7 @@ elementselector::elementselector(std::vector<int> disjointregionnumbers, bool is
     
     int currentindex = 0;
     elements* myelements = universe::mymesh->getelements();
-    for (int i = 0; i < mydisjointregionnumbers.size(); i++)
+    for (size_t i = 0; i < mydisjointregionnumbers.size(); i++)
     {
         int numelemindisjreg = universe::mymesh->getdisjointregions()->countelements(mydisjointregionnumbers[i]);
         int myelementtypenumber = universe::mymesh->getdisjointregions()->getelementtypenumber(mydisjointregionnumbers[i]);
@@ -95,7 +95,7 @@ elementselector::elementselector(std::vector<int> disjointregionnumbers, std::ve
     int myelementtypenumber = universe::mymesh->getdisjointregions()->getelementtypenumber(mydisjointregionnumbers[0]);
     
     elements* myelements = universe::mymesh->getelements();
-    for (int i = 0; i < elemnums.size(); i++)
+    for (size_t i = 0; i < elemnums.size(); i++)
     {
         disjointregions[i] = myelements->getdisjointregion(myelementtypenumber, elemnums[i]);
         totalorientations[i] = myelements->gettotalorientation(myelementtypenumber, elemnums[i]);
@@ -160,7 +160,7 @@ int elementselector::countinselection(void)
         {
             // 'isdisjregrequested[disjreg]' is true if disjreg is in 'selecteddisjointregions'.
             std::vector<bool> isdisjregrequested(*std::max_element(mydisjointregionnumbers.begin(), mydisjointregionnumbers.end())+1, false);
-            for (int i = 0; i < selecteddisjointregions.size(); i++)
+            for (size_t i = 0; i < selecteddisjointregions.size(); i++)
                 isdisjregrequested[selecteddisjointregions[i]] = true;
             
             int numinselection = 0;
@@ -189,7 +189,7 @@ std::vector<int> elementselector::getelementnumbers(void)
     {
         // 'isdisjregrequested[disjreg]' is true if disjreg is in 'disjregs'.
         std::vector<bool> isdisjregrequested(*std::max_element(mydisjointregionnumbers.begin(), mydisjointregionnumbers.end())+1, false);
-        for (int i = 0; i < selecteddisjointregions.size(); i++)
+        for (size_t i = 0; i < selecteddisjointregions.size(); i++)
             isdisjregrequested[selecteddisjointregions[i]] = true;
         
         int index = 0;
@@ -220,7 +220,7 @@ std::vector<int> elementselector::getelementindexes(void)
     {
         // 'isdisjregrequested[disjreg]' is true if disjreg is in 'disjregs'.
         std::vector<bool> isdisjregrequested(*std::max_element(mydisjointregionnumbers.begin(), mydisjointregionnumbers.end())+1, false);
-        for (int i = 0; i < selecteddisjointregions.size(); i++)
+        for (size_t i = 0; i < selecteddisjointregions.size(); i++)
             isdisjregrequested[selecteddisjointregions[i]] = true;
         
         int index = 0;
@@ -251,7 +251,7 @@ std::vector<int> elementselector::getoriginalindexes(void)
     {
         // 'isdisjregrequested[disjreg]' is true if disjreg is in 'disjregs'.
         std::vector<bool> isdisjregrequested(*std::max_element(mydisjointregionnumbers.begin(), mydisjointregionnumbers.end())+1, false);
-        for (int i = 0; i < selecteddisjointregions.size(); i++)
+        for (size_t i = 0; i < selecteddisjointregions.size(); i++)
             isdisjregrequested[selecteddisjointregions[i]] = true;
         
         int index = 0;

--- a/src/mesh/htracker.cpp
+++ b/src/mesh/htracker.cpp
@@ -203,7 +203,7 @@ int htracker::next(void)
                 for (int j = 0; j < cornerrefcoords[i].size()/nn[i]/3; j++)
                 {
                     std::vector<double> cc(3*nn[i]);
-                    for (int k = 0; k < cc.size(); k++)
+                    for (size_t k = 0; k < cc.size(); k++)
                         cc[k] = cornerrefcoords[i][j*3*nn[i]+k];
                     
                     parentrefcoords[currentdepth+1][ind] = myelems[t].calculatecoordinates(cc, parentrefcoords[currentdepth][ic]);
@@ -450,7 +450,7 @@ void htracker::adapt(std::vector<int>& operations)
 {
     // Calculate an upper bound for the size of the new 'splitdata' vector:
     int upperbound = splitdata.size();
-    for (int i = 0; i < operations.size(); i++)
+    for (size_t i = 0; i < operations.size(); i++)
     {
         if (operations[i] == 1)
             upperbound += 10; // 10 is the max size increase in a split
@@ -593,7 +593,7 @@ void htracker::atleaves(std::vector<std::vector<double>>& arc, std::vector<std::
             if (withphysicals)
                 physcoords = myelems[parenttypes[0]].calculatecoordinates(refcoords, oc, 0, ns == 0);
             
-            for (int i = 0; i < refcoords.size(); i++)
+            for (size_t i = 0; i < refcoords.size(); i++)
             {
                 arc[t][iarc[t]+i] = refcoords[i];
                 if (withphysicals)
@@ -624,7 +624,7 @@ void htracker::getadaptedcoordinates(std::vector<std::vector<double>>& ac)
     
     // Assign unique edge numbers and deduce edge splits:
     std::vector<int> edgenumbers;
-    std:vector<bool> isedgesplit;
+    std::vector<bool> isedgesplit;
     myalgorithm::assignedgenumbers(cornerapc, edgenumbers, isedgesplit);
     
 
@@ -696,7 +696,7 @@ void htracker::getadaptedcoordinates(std::vector<std::vector<double>>& ac)
                 // Bring inside the untransitioned element (if split at all):
                 curcoords = myelems[t].calculatecoordinates(curcoords, cornerarc[t], iarc[t], splitnum == 0);
                 
-                for (int i = 0; i < curcoords.size(); i++)
+                for (size_t i = 0; i < curcoords.size(); i++)
                     transitionsrefcoords[si][3*nn[si]*ite[si]+i] = curcoords[i];
                 
                 // Make curved:
@@ -706,7 +706,7 @@ void htracker::getadaptedcoordinates(std::vector<std::vector<double>>& ac)
                 // Calculate actual coordinates: 
                 curcoords = mycurvedelems[parenttypes[0]].calculatecoordinates(curcoords, oc, 0);
 
-                for (int i = 0; i < curcoords.size(); i++)
+                for (size_t i = 0; i < curcoords.size(); i++)
                     ac[si][3*ncn[si]*ite[si]+i] = curcoords[i];
                     
                 leavesoftransitions[si][ite[si]] = ln;
@@ -941,7 +941,7 @@ void htracker::fromoriginal(std::vector<int>& oad, std::vector<double>& orc, std
                         polynomials syspolys = polys[i].sum(xyz);
                 
                         // Loop on all actives:
-                        for (int j = 0; j < activesintrans.size(); j++)
+                        for (size_t j = 0; j < activesintrans.size(); j++)
                         {                        
                             std::vector<double> kietaphi = {0.0,0.0,0.0};
                             std::vector<double> rhs = {orc[3*activesintrans[j]+0], orc[3*activesintrans[j]+1], orc[3*activesintrans[j]+2]};
@@ -982,7 +982,7 @@ void htracker::fromoriginal(std::vector<int>& oad, std::vector<double>& orc, std
     }
     
     // Sanity check:
-    for (int i = 0; i < maporctorc.size(); i++)
+    for (size_t i = 0; i < maporctorc.size(); i++)
     {
         if (maporctorc[i] < 0)
         {
@@ -1170,7 +1170,7 @@ void htracker::print(void)
 {
     std::cout << "#leaves is " << numleaves << " | max #splits is " << maxdepth << std::endl;
 
-    for (int i = 0; i < splitdata.size(); i++)
+    for (size_t i = 0; i < splitdata.size(); i++)
         std::cout << splitdata[i];
         
     std::cout << " (" << splitdata.size() << " bits)" << std::endl;

--- a/src/mesh/myalgorithm.cpp
+++ b/src/mesh/myalgorithm.cpp
@@ -592,7 +592,7 @@ std::vector<std::vector<double>> myalgorithm::splitvector(std::vector<double>& t
 void myalgorithm::splitvector(std::vector<int>& vec, std::vector<bool>& select, std::vector<int>& falses, std::vector<int>& trues)
 {
     int numtrue = 0;
-    for (int i = 0; i < select.size(); i++)
+    for (size_t i = 0; i < select.size(); i++)
     {
         if (select[i])
             numtrue++;
@@ -602,7 +602,7 @@ void myalgorithm::splitvector(std::vector<int>& vec, std::vector<bool>& select, 
     falses = std::vector<int>(select.size()-numtrue);
     
     int indt = 0, indf = 0;
-    for (int i = 0; i < select.size(); i++)
+    for (size_t i = 0; i < select.size(); i++)
     {
         if (select[i])
         {
@@ -885,7 +885,7 @@ std::vector<double> myalgorithm::separate(std::vector<double>& v, int blocklen, 
     
     std::vector<double> output(sel.size() * numblocks);
     
-    for (int s = 0; s < sel.size(); s++)
+    for (size_t s = 0; s < sel.size(); s++)
     {
         for (int b = 0; b < numblocks; b++)
             output[s*numblocks+b] = v[b*blocklen + sel[s]];
@@ -898,7 +898,7 @@ std::vector<int> myalgorithm::chainrenumbering(std::vector<int>& originalrenum, 
 {
     std::vector<int> output(originalrenum.size());
 
-    for (int i = 0; i < originalrenum.size(); i++)
+    for (size_t i = 0; i < originalrenum.size(); i++)
         output[i] = newrenum[originalrenum[i]];
 
     return output;
@@ -908,7 +908,7 @@ std::vector<int> myalgorithm::invertrenumbering(std::vector<int>& renum)
 {
     std::vector<int> output(renum.size());
 
-    for (int i = 0; i < renum.size(); i++)
+    for (size_t i = 0; i < renum.size(); i++)
         output[renum[i]] = i;
 
     return output;
@@ -918,7 +918,7 @@ std::vector<int> myalgorithm::getreordering(std::vector<int>& renum)
 {
     std::vector<int> out(renum.size());
     
-    for (int i = 0; i < renum.size(); i++)
+    for (size_t i = 0; i < renum.size(); i++)
         out[renum[i]] = i;
     
     return out;
@@ -989,7 +989,7 @@ void myalgorithm::toaddressdata(std::vector<int>& elems, std::vector<double>& re
             continue;
     
         ads[i] = std::vector<int>(cnt[i].size()+1,0);
-        for (int j = 1; j < ads[i].size(); j++)
+        for (size_t j = 1; j < ads[i].size(); j++)
             ads[i][j] = ads[i][j-1] + 3*cnt[i][j-1];
             
         rcs[i] = std::vector<double>(3*countintype[i]);
@@ -1016,14 +1016,14 @@ std::vector<int> myalgorithm::concatenate(std::vector<std::vector<int>> tocat)
 {
     // Get the total size:
     int len = 0;
-    for (int i = 0; i < tocat.size(); i++)
+    for (size_t i = 0; i < tocat.size(); i++)
         len += tocat[i].size();
         
     std::vector<int> output(len);
     int index = 0;
-    for (int i = 0; i < tocat.size(); i++)
+    for (size_t i = 0; i < tocat.size(); i++)
     {
-        for (int j = 0; j < tocat[i].size(); j++)
+        for (size_t j = 0; j < tocat[i].size(); j++)
         {
             output[index] = tocat[i][j];
             index++;
@@ -1050,12 +1050,12 @@ void myalgorithm::normvector(std::vector<double>& tonorm)
 {
     // Compute the norm:
     double nrm = 0.0;
-    for (int i = 0; i < tonorm.size(); i++)
+    for (size_t i = 0; i < tonorm.size(); i++)
         nrm += tonorm[i]*tonorm[i];
     nrm = std::sqrt(nrm);
     double invnrm = 1.0/nrm;
 
-    for (int i = 0; i < tonorm.size(); i++)
+    for (size_t i = 0; i < tonorm.size(); i++)
         tonorm[i] = invnrm * tonorm[i];
 }
 

--- a/src/mesh/myalgorithm.h
+++ b/src/mesh/myalgorithm.h
@@ -152,6 +152,6 @@ namespace myalgorithm
     // Norm a vector:
     void normvector(std::vector<double>& tonorm);
     
-};
+}
 
 #endif

--- a/src/mesh/nodes.cpp
+++ b/src/mesh/nodes.cpp
@@ -43,7 +43,7 @@ std::vector<int> nodes::removeduplicates(void)
     std::vector<int> noderenumbering;
     int numberofnonduplicates = myalgorithm::removeduplicates(mycoordinates, noderenumbering);
 
-    for (int i = 0; i < noderenumbering.size(); i++)
+    for (size_t i = 0; i < noderenumbering.size(); i++)
     {
         if (noderenumbering[i] != i)
         {

--- a/src/mesh/petscmesh.cpp
+++ b/src/mesh/petscmesh.cpp
@@ -26,7 +26,7 @@ petscmesh::petscmesh(std::string filename)
     bool isvalidext = false;
     
     std::string curfileext = myalgorithm::getfileextension(filename);
-    for (int i = 0; i < supportedextensions.size(); i++)
+    for (size_t i = 0; i < supportedextensions.size(); i++)
     {
         if (supportedextensions[i] == curfileext)
         {

--- a/src/mesh/physicalregion.cpp
+++ b/src/mesh/physicalregion.cpp
@@ -35,7 +35,7 @@ int physicalregion::countelements(void)
 {
     std::vector<int> alldisjointregions = getdisjointregions();
     int numelem = 0;
-    for (int i = 0; i < alldisjointregions.size(); i++)
+    for (size_t i = 0; i < alldisjointregions.size(); i++)
         numelem += mydisjointregions->countelements(alldisjointregions[i]);
     return numelem;
 }
@@ -68,7 +68,7 @@ void physicalregion::setdisjointregions(std::vector<int> disjointregionlist)
     std::fill(includesdisjointregion.begin(), includesdisjointregion.end(), false);
 
     myelementdimension = mydisjointregions->getelementdimension(disjointregionlist[0]);
-    for (int i = 0; i < disjointregionlist.size(); i++)
+    for (size_t i = 0; i < disjointregionlist.size(); i++)
     {
         includesdisjointregion[disjointregionlist[i]] = true;
         if (myelementdimension < mydisjointregions->getelementdimension(disjointregionlist[i]))
@@ -84,7 +84,7 @@ std::vector<bool> physicalregion::getdefinition(void)
 std::vector<int> physicalregion::getdisjointregions(void)
 {
     std::vector<int> disjointregionlist;
-    for (int i = 0; i < includesdisjointregion.size(); i++)
+    for (size_t i = 0; i < includesdisjointregion.size(); i++)
     {
         // Only disjoint regions including elements of the same 
         // dimension as in the physical region are selected.
@@ -97,7 +97,7 @@ std::vector<int> physicalregion::getdisjointregions(void)
 std::vector<int> physicalregion::getdisjointregions(int dim)
 {
     std::vector<int> disjointregionlist;
-    for (int i = 0; i < includesdisjointregion.size(); i++)
+    for (size_t i = 0; i < includesdisjointregion.size(); i++)
     {
         if (includesdisjointregion[i])
         {
@@ -112,7 +112,7 @@ std::vector<int> physicalregion::getdisjointregions(int dim)
 void physicalregion::renumberelements(int elementtypenumber, std::vector<int>& elementrenumbering)
 {
     // Update 'elementlist'.
-    for (int i = 0; i < elementlist[elementtypenumber].size(); i++)
+    for (size_t i = 0; i < elementlist[elementtypenumber].size(); i++)
         elementlist[elementtypenumber][i] = elementrenumbering[elementlist[elementtypenumber][i]];
 }
 
@@ -152,7 +152,7 @@ std::vector<std::vector<int>>* physicalregion::getelementlist(void)
     {
         // First preallocate:
         std::vector<int> sizes(8,0);
-        for (int d = 0; d < includesdisjointregion.size(); d++)
+        for (size_t d = 0; d < includesdisjointregion.size(); d++)
         {
             if (includesdisjointregion[d] && mydisjointregions->getelementdimension(d) == myelementdimension)
                 sizes[mydisjointregions->getelementtypenumber(d)] += mydisjointregions->countelements(d);
@@ -162,7 +162,7 @@ std::vector<std::vector<int>>* physicalregion::getelementlist(void)
     
         // Loop on all disjoint regions of the right dimension:
         std::vector<int> curindexes(8,0);
-        for (int d = 0; d < includesdisjointregion.size(); d++)
+        for (size_t d = 0; d < includesdisjointregion.size(); d++)
         {
             if (includesdisjointregion[d] && mydisjointregions->getelementdimension(d) == myelementdimension)
             {

--- a/src/mesh/physicalregions.cpp
+++ b/src/mesh/physicalregions.cpp
@@ -13,11 +13,11 @@ int physicalregions::createunion(const std::vector<int> input)
     errornotsamedim(input);
 
     std::vector<int> disjregs = {};
-    for (int i = 0; i < input.size(); i++)
+    for (size_t i = 0; i < input.size(); i++)
     {
         // Get all disjoint regions with -1:
         std::vector<int> disjregsinthisphysreg = get(input[i])->getdisjointregions(-1);
-        for (int j = 0; j < disjregsinthisphysreg.size(); j++)
+        for (size_t j = 0; j < disjregsinthisphysreg.size(); j++)
             disjregs.push_back(disjregsinthisphysreg[j]);
     }
     int newphysregnum = getmaxphysicalregionnumber() + 1;
@@ -33,7 +33,7 @@ int physicalregions::createintersection(const std::vector<int> input)
     errorundefined(input);
 
     std::vector<int> disjregs = {};
-    for (int i = 0; i < input.size(); i++)
+    for (size_t i = 0; i < input.size(); i++)
     {
         // Get all disjoint regions with -1:
         std::vector<int> disjregsinthisphysreg = get(input[i])->getdisjointregions(-1);
@@ -58,7 +58,7 @@ int physicalregions::createunionofall(void)
     std::vector<int> tounite = {};
     
     // Get all regions of max dimension:
-    for (int i = 0; i < myphysicalregionnumbers.size(); i++)
+    for (size_t i = 0; i < myphysicalregionnumbers.size(); i++)
     {
         if (myphysicalregions[i]->getelementdimension() == problemdimension)
             tounite.push_back(myphysicalregionnumbers[i]);
@@ -85,7 +85,7 @@ int physicalregions::getmaxphysicalregionnumber(void)
 physicalregion* physicalregions::get(int physicalregionnumber)
 {        
     // Try to find the physical region number in 'myphysicalregionnumbers':
-    for (int i = 0; i < myphysicalregionnumbers.size(); i++)
+    for (size_t i = 0; i < myphysicalregionnumbers.size(); i++)
     {
         if (myphysicalregionnumbers[i] == physicalregionnumber)
             return myphysicalregions[i].get();
@@ -111,7 +111,7 @@ int physicalregions::count(int dim)
     else
     {
         int num = 0;
-        for (int i = 0; i < myphysicalregionnumbers.size(); i++)
+        for (size_t i = 0; i < myphysicalregionnumbers.size(); i++)
         {
             if (myphysicalregions[i]->getelementdimension() == dim)
                 num++;
@@ -123,7 +123,7 @@ int physicalregions::count(int dim)
 int physicalregions::countelements(void)
 {
     int numelem = 0;
-    for (int i = 0; i < myphysicalregions.size(); i++)
+    for (size_t i = 0; i < myphysicalregions.size(); i++)
         numelem += myphysicalregions[i]->countelements();
     
     return numelem;
@@ -136,8 +136,8 @@ std::vector<int> physicalregions::getallnumbers(int dim)
     else
     {
         std::vector<int> out(count(dim));
-        int index = 0;
-        for (int i = 0; i < myphysicalregions.size(); i++)
+        size_t index = 0;
+        for (size_t i = 0; i < myphysicalregions.size(); i++)
         {
             if (myphysicalregions[i]->getelementdimension() == dim)
             {   
@@ -156,7 +156,7 @@ int physicalregions::getnumber(int physicalregionindex)
 
 int physicalregions::getindex(int physicalregionnumber)
 {
-    for (int i = 0; i < myphysicalregionnumbers.size(); i++)
+    for (size_t i = 0; i < myphysicalregionnumbers.size(); i++)
     {
         if (myphysicalregionnumbers[i] == physicalregionnumber)
             return i;
@@ -170,12 +170,12 @@ void physicalregions::inphysicalregions(int elementtypenumber, int totalnumelems
     int dim = myelem.getelementdimension();
 
     std::vector<int> numprinelems(totalnumelemsintype, 0);
-    for (int i = 0; i < myphysicalregionnumbers.size(); i++)
+    for (size_t i = 0; i < myphysicalregionnumbers.size(); i++)
     {
         if (myphysicalregions[i]->getelementdimension() != dim)
             continue;
         std::vector<int>* ellist = &(myphysicalregions[i]->getelementlist()->at(elementtypenumber));
-        for (int j = 0; j < ellist->size(); j++)
+        for (size_t j = 0; j < ellist->size(); j++)
             numprinelems[ellist->at(j)]++;
     }
 
@@ -186,13 +186,13 @@ void physicalregions::inphysicalregions(int elementtypenumber, int totalnumelems
     // Populate:
     prs = std::vector<int>(addresses[totalnumelemsintype]);
     std::vector<int> ind(totalnumelemsintype, 0);
-    for (int i = 0; i < myphysicalregionnumbers.size(); i++)
+    for (size_t i = 0; i < myphysicalregionnumbers.size(); i++)
     {
         if (myphysicalregions[i]->getelementdimension() != dim)
             continue;
         int curpr = myphysicalregionnumbers[i];
         std::vector<int>* ellist = &(myphysicalregions[i]->getelementlist()->at(elementtypenumber));
-        for (int j = 0; j < ellist->size(); j++)
+        for (size_t j = 0; j < ellist->size(); j++)
         {
             int curel = ellist->at(j);
             prs[addresses[curel]+ind[curel]] = curpr;
@@ -206,7 +206,7 @@ void physicalregions::remove(std::vector<int> toremove, bool ispartofdisjregstru
     // Tag regions to remove:
     std::vector<bool> istoremove(myphysicalregionnumbers.size(), false);
 
-    for (int i = 0; i < toremove.size(); i++)
+    for (size_t i = 0; i < toremove.size(); i++)
     {
         int curindex = getindex(toremove[i]);
         if (curindex != -1)
@@ -214,7 +214,7 @@ void physicalregions::remove(std::vector<int> toremove, bool ispartofdisjregstru
     }
 
     int index = 0;
-    for (int i = 0; i < myphysicalregionnumbers.size(); i++)
+    for (size_t i = 0; i < myphysicalregionnumbers.size(); i++)
     {
         if (not(istoremove[i]))
         {
@@ -233,7 +233,7 @@ void physicalregions::remove(std::vector<int> toremove, bool ispartofdisjregstru
 
 void physicalregions::errorundefined(std::vector<int> physregs)
 {
-    for (int i = 0; i < physregs.size(); i++)
+    for (size_t i = 0; i < physregs.size(); i++)
     {
         if (getindex(physregs[i]) == -1)
         {
@@ -250,7 +250,7 @@ void physicalregions::errornotsamedim(std::vector<int> physregs)
 
     int dim = get(physregs[0])->getelementdimension();
 
-    for (int i = 1; i < physregs.size(); i++)
+    for (size_t i = 1; i < physregs.size(); i++)
     {
         int curdim = get(physregs[i])->getelementdimension();
         if (dim != curdim)
@@ -265,7 +265,7 @@ void physicalregions::copy(disjointregions* drs, physicalregions* target)
 {
     *target = *this;
     
-    for (int i = 0; i < myphysicalregions.size(); i++)
+    for (size_t i = 0; i < myphysicalregions.size(); i++)
         target->myphysicalregions[i] = myphysicalregions[i]->copy(target, drs);
     
     target->mydisjointregions = drs;

--- a/src/mesh/ptracker.cpp
+++ b/src/mesh/ptracker.cpp
@@ -18,7 +18,7 @@ void ptracker::updaterenumbering(std::vector<std::vector<int>>& renumber)
     for (int i = 0; i < 8; i++)
     {
         std::vector<int> oldrenum = elementrenumbering[i]; 
-        for (int j = 0; j < elementrenumbering[i].size(); j++)
+        for (size_t j = 0; j < elementrenumbering[i].size(); j++)
             elementrenumbering[i][j] = renumber[i][oldrenum[j]];
     }
 }
@@ -32,12 +32,12 @@ void ptracker::getrenumbering(std::shared_ptr<ptracker> mt, std::vector<std::vec
         renumbering[i].resize(elementrenumbering[i].size());
         if (mt != NULL)
         {
-            for (int j = 0; j < elementrenumbering[i].size(); j++)
+            for (size_t j = 0; j < elementrenumbering[i].size(); j++)
                 renumbering[i][elementrenumbering[i][j]] = mt->elementrenumbering[i][j];
         }
         else
         {
-            for (int j = 0; j < elementrenumbering[i].size(); j++)
+            for (size_t j = 0; j < elementrenumbering[i].size(); j++)
                 renumbering[i][elementrenumbering[i][j]] = j;
         }
     }
@@ -69,10 +69,10 @@ void ptracker::getindisjointregions(std::vector<std::vector<int>>& indisjregs)
 
 void ptracker::print(void)
 {
-    for (int i = 0; i < elementrenumbering.size(); i++)
+    for (size_t i = 0; i < elementrenumbering.size(); i++)
     {
         std::cout << std::endl << "Element type number " << i << ":" << std::endl << std::endl;
-        for (int j = 0; j < elementrenumbering[i].size(); j++)
+        for (size_t j = 0; j < elementrenumbering[i].size(); j++)
             std::cout << j << " --> " << elementrenumbering[i][j] << std::endl;
     }
     std::cout << std::endl;

--- a/src/mesh/rawmesh.cpp
+++ b/src/mesh/rawmesh.cpp
@@ -22,7 +22,7 @@ void rawmesh::splitmesh(void)
     // Loop on all physical regions:
     int numnodes = 0;
     std::vector< std::vector<std::vector<double>> > splitcoords(prn.size(), std::vector<std::vector<double>>(8, std::vector<double>(0)));
-    for (int p = 0; p < prn.size(); p++)
+    for (size_t p = 0; p < prn.size(); p++)
     {
         physicalregion* curpr = myphysicalregions.getatindex(p);
         std::vector<std::vector<int>>* curelemlist = curpr->getelementlist();
@@ -57,7 +57,7 @@ void rawmesh::splitmesh(void)
             {
                 int el = curelemlist->at(i)[e];
                 std::vector<double> curcoords = myelements.getnodecoordinates(i,el);
-                for (int j = 0; j < curcoords.size(); j++)
+                for (size_t j = 0; j < curcoords.size(); j++)
                     coords[3*ncn[i]*e+j] = curcoords[j];
             }
             element myelem(i,co);
@@ -67,7 +67,7 @@ void rawmesh::splitmesh(void)
             // Group with the existing splitcoords[p]:
             for (int j = 0; j < 8; j++)
             {
-                for (int k = 0; k < tempsplit[j].size(); k++)
+                for (size_t k = 0; k < tempsplit[j].size(); k++)
                     splitcoords[p][j][indexes[j]+k] = tempsplit[j][k];
                 indexes[j] += tempsplit[j].size();
             }
@@ -83,7 +83,7 @@ void rawmesh::splitmesh(void)
     mynodes.setnumber(numnodes);
     std::vector<double>* nc = mynodes.getcoordinates();
     int nindex = 0;
-    for (int p = 0; p < splitcoords.size(); p++)
+    for (size_t p = 0; p < splitcoords.size(); p++)
     {
         physicalregion* curpr = myphysicalregions.get(prn[p]);
         
@@ -358,7 +358,7 @@ void rawmesh::load(bool mergeduplicates, std::vector<std::string> meshfiles, int
     
         for (int d = 0; d < 4; d++)
         {
-            for (int s = 0; s < allshapes[i][d].size(); s++)
+            for (size_t s = 0; s < allshapes[i][d].size(); s++)
             {
                 if (mergeduplicates == false)
                     allshapes[i][d][s].getpointer()->shift(shiftvec[i],0,0, false);
@@ -408,7 +408,7 @@ void rawmesh::load(std::vector<shape> inputshapes, int verbosity)
     }
 
     // Make sure all shapes have a valid physical region number:
-    for (int i = 0; i < inputshapes.size(); i++)
+    for (size_t i = 0; i < inputshapes.size(); i++)
     {
         if (inputshapes[i].getphysicalregion() <= 0)
         {
@@ -419,7 +419,7 @@ void rawmesh::load(std::vector<shape> inputshapes, int verbosity)
 
     // Get the number of nodes for preallocation:
     int numberofnodes = 0;
-    for (int i = 0; i < inputshapes.size(); i++)
+    for (size_t i = 0; i < inputshapes.size(); i++)
         numberofnodes += ( inputshapes[i].getpointer()->getcoords() )->size()/3;
     mynodes.setnumber(numberofnodes);
     std::vector<double>* nodecoordinates = mynodes.getcoordinates();
@@ -428,11 +428,11 @@ void rawmesh::load(std::vector<shape> inputshapes, int verbosity)
     // The node numbers must be shifted from a shape to the other to avoid same numbers:
     int offset = 0;
     // Loop on every input shape:
-    for (int i = 0; i < inputshapes.size(); i++)
+    for (size_t i = 0; i < inputshapes.size(); i++)
     {
         // Append the nodes:
         std::vector<double>* nodecoords = inputshapes[i].getpointer()->getcoords();
-        for (int j = 0; j < nodecoords->size(); j++)
+        for (size_t j = 0; j < nodecoords->size(); j++)
             nodecoordinates->at(3*offset+j) = nodecoords->at(j);
 
         // Append the elements:
@@ -440,7 +440,7 @@ void rawmesh::load(std::vector<shape> inputshapes, int verbosity)
         physicalregion* currentphysicalregion = myphysicalregions.get(physreg);
         std::vector<std::vector<int>>* elems = inputshapes[i].getpointer()->getelems();
         // Loop on all element types:
-        for (int typenum = 0; typenum < elems->size(); typenum++)
+        for (size_t typenum = 0; typenum < elems->size(); typenum++)
         {
             element currentelem(typenum, curvatureorder);
             // Number of nodes in every element of current type number:
@@ -448,7 +448,7 @@ void rawmesh::load(std::vector<shape> inputshapes, int verbosity)
 
             std::vector<int> nodesincurrentelement(numnodesinelem);
 
-            for (int e = 0; e < (elems->at(typenum)).size()/numnodesinelem; e++)
+            for (size_t e = 0; e < (elems->at(typenum)).size()/numnodesinelem; e++)
             {
                 for (int m = 0; m < numnodesinelem; m++)
                     nodesincurrentelement[m] = (elems->at(typenum))[e*numnodesinelem+m] + offset;
@@ -534,7 +534,7 @@ void rawmesh::split(int n)
 
 std::vector<bool> rawmesh::isnodeinphysicalregion(int physreg)
 {
-    int numberofnodes = mynodes.count();
+    size_t numberofnodes = mynodes.count();
     
     std::vector<bool> output;
 
@@ -547,7 +547,7 @@ std::vector<bool> rawmesh::isnodeinphysicalregion(int physreg)
         // Get only the disjoint regions with highest dimension elements:
         std::vector<int> selecteddisjregs = myphysicalregions.get(physreg)->getdisjointregions();
     
-        for (int i = 0; i < selecteddisjregs.size(); i++)
+        for (size_t i = 0; i < selecteddisjregs.size(); i++)
         {
             int disjreg = selecteddisjregs[i];
             int numelems = mydisjointregions.countelements(disjreg);
@@ -630,7 +630,7 @@ void rawmesh::move(int physreg, expression u)
             std::vector<int> elementnumbers = myselector.getelementnumbers();
 
             // Loop on all elements:
-            for (int e = 0; e < elementnumbers.size(); e++)
+            for (size_t e = 0; e < elementnumbers.size(); e++)
             {
                 for (int n = 0; n < ncn; n++)
                 {
@@ -1043,7 +1043,7 @@ void rawmesh::getattarget(std::vector<std::vector<int>>& values, std::shared_ptr
 void rawmesh::add(std::shared_ptr<rawfield> inrawfield, expression criterion, int loworder, int highorder)
 {
     int index = -1;
-    for (int i = 0; i < mypadaptdata.size(); i++)
+    for (size_t i = 0; i < mypadaptdata.size(); i++)
     {
         std::shared_ptr<rawfield> currawfield = (std::get<0>(mypadaptdata[i])).lock();
         if (currawfield.get() == inrawfield.get())
@@ -1068,7 +1068,7 @@ void rawmesh::remove(rawfield* inrawfield)
     
     // Remove the pointed field and all expired fields:
     int curindex = 0;
-    for (int i = 0; i < mypadaptdata.size(); i++)
+    for (size_t i = 0; i < mypadaptdata.size(); i++)
     {
         std::weak_ptr<rawfield> curwp = std::get<0>(mypadaptdata[i]);
         if (not(curwp.expired()))
@@ -1098,7 +1098,7 @@ bool rawmesh::adaptp(std::vector<std::vector<std::vector<int>>>& neworders, int 
     {
         for (int i = 0; i < 8; i++)
         {
-            for (int e = 0; e < neworders[f][i].size(); e++)
+            for (size_t e = 0; e < neworders[f][i].size(); e++)
             {
                 if (neworders[f][i][e] > newmaxorder)
                     newmaxorder = neworders[f][i][e];
@@ -1119,7 +1119,7 @@ bool rawmesh::adaptp(std::vector<std::vector<std::vector<int>>>& neworders, int 
     {
         for (int i = 0; i < 8; i++)
         {
-            for (int e = 0; e < neworders[f][i].size(); e++)
+            for (size_t e = 0; e < neworders[f][i].size(); e++)
             {
                 int curorder = neworders[f][i][e];
 
@@ -1175,7 +1175,7 @@ bool rawmesh::adaptp(std::vector<std::vector<std::vector<int>>>& neworders, int 
     {
         std::vector<int> curphysregsfororder = {};
         
-        for (int o = 0; o < newphysregsfororder[i].size(); o++)
+        for (size_t o = 0; o < newphysregsfororder[i].size(); o++)
         {   
             for (int typenum = 0; typenum < 8; typenum++)
             {
@@ -1197,7 +1197,7 @@ bool rawmesh::adaptp(std::vector<std::vector<std::vector<int>>>& neworders, int 
     ///// Remove the physical regions created:
     
     std::vector<int> prtoremove(newlastpr-lastphysregnum);
-    for (int i = 0; i < prtoremove.size(); i++)
+    for (size_t i = 0; i < prtoremove.size(); i++)
         prtoremove[i] = lastphysregnum+1+i;
     myphysicalregions.remove(prtoremove, true);
     
@@ -1253,7 +1253,7 @@ bool rawmesh::adapth(std::vector<std::vector<int>>& groupkeepsplit, int verbosit
     
     for (int i = 0; i < 8; i++)
     {
-        for (int e = 0; e < groupkeepsplit[i].size(); e++)
+        for (size_t e = 0; e < groupkeepsplit[i].size(); e++)
         {
             int ln = newhtracker->getleafnumber(i, e);
             int decision = groupkeepsplit[i][e];
@@ -1281,7 +1281,7 @@ bool rawmesh::adapth(std::vector<std::vector<int>>& groupkeepsplit, int verbosit
             element myelement(i);
             int numedges = myelement.countedges();
         
-            for (int e = 0; e < groupkeepsplit[i].size(); e++)
+            for (size_t e = 0; e < groupkeepsplit[i].size(); e++)
             {
                 int ln = newhtracker->getleafnumber(i, e);
                 int numsplits = leavesnumsplits[ln] + vadapt[ln];
@@ -1296,7 +1296,7 @@ bool rawmesh::adapth(std::vector<std::vector<int>>& groupkeepsplit, int verbosit
                     // Get all cells touching the current edge:
                     std::vector<int> cellsonedge = elptr->getcellsonedge(currentedge);
 
-                    for (int c = 0; c < cellsonedge.size()/2; c++)
+                    for (size_t c = 0; c < cellsonedge.size()/2; c++)
                     {
                         int curcell = cellsonedge[2*c+1];
                         int celltype = cellsonedge[2*c+0];
@@ -1319,7 +1319,7 @@ bool rawmesh::adapth(std::vector<std::vector<int>>& groupkeepsplit, int verbosit
     // Nothing to do if all new number of splits are identical to the old ones:
     newhtracker->fix(vadapt);
     bool isidentical = true;
-    for (int i = 0; i < vadapt.size(); i++)
+    for (size_t i = 0; i < vadapt.size(); i++)
     {
         if (vadapt[i] != 0)
         {
@@ -1430,7 +1430,7 @@ bool rawmesh::adapth(std::vector<std::vector<int>>& groupkeepsplit, int verbosit
             
             if (isanypratdim[0])
             {
-                for (int n = 0; n < on.size(); n++)
+                for (size_t n = 0; n < on.size(); n++)
                 {
                     if (on[n] != -1)
                     {
@@ -1445,7 +1445,7 @@ bool rawmesh::adapth(std::vector<std::vector<int>>& groupkeepsplit, int verbosit
             }
             if (isanypratdim[1])
             {
-                for (int e = 0; e < oe.size(); e++)
+                for (size_t e = 0; e < oe.size(); e++)
                 {
                     if (oe[e] != -1)
                     {
@@ -1460,7 +1460,7 @@ bool rawmesh::adapth(std::vector<std::vector<int>>& groupkeepsplit, int verbosit
             }
             if (isanypratdim[2])
             {
-                for (int f = 0; f < of.size(); f++)
+                for (size_t f = 0; f < of.size(); f++)
                 {
                     if (of[f] != -1)
                     {
@@ -1573,7 +1573,7 @@ void rawmesh::printphysicalregions(void)
         
         std::vector<int> disjointregionlist = currentphysicalregion->getdisjointregions();
         // Print the disjoint region list:
-        for (int i = 0; i < disjointregionlist.size(); i++)
+        for (size_t i = 0; i < disjointregionlist.size(); i++)
             std::cout << disjointregionlist[i] << " ";
         
         std::cout << std::endl;
@@ -1616,12 +1616,12 @@ void rawmesh::printelementsinphysicalregions(bool isdebug)
             
             std::vector<std::vector<int>>* elemlist = currentphysicalregion->getelementlist();
 
-            for (int i = 0; i < elemlist->size(); i++)
+            for (size_t i = 0; i < elemlist->size(); i++)
             {
                 if (elemlist->at(i).size() > 0)
                 {
                     std::cout << " (" << i << "): ";
-                    for (int j = 0; j < elemlist->at(i).size(); j++)
+                    for (size_t j = 0; j < elemlist->at(i).size(); j++)
                         std::cout << elemlist->at(i)[j] << " ";
                 }
             }

--- a/src/mesh/referencecoordinategroup.cpp
+++ b/src/mesh/referencecoordinategroup.cpp
@@ -21,7 +21,7 @@ void referencecoordinategroup::evalat(std::vector<int> inputdisjregs)
     std::iota(coordnums.begin(), coordnums.end(), 0);
     std::vector<double> kietaphis(3*numcoords,0.0);
     
-    for (int d = 0; d < inputdisjregs.size(); d++)
+    for (size_t d = 0; d < inputdisjregs.size(); d++)
         myalgorithm::getreferencecoordinates(mycoordgroup, inputdisjregs[d], elems, kietaphis);
         
     evalat(elems, kietaphis, coordnums);  
@@ -30,7 +30,7 @@ void referencecoordinategroup::evalat(std::vector<int> inputdisjregs)
 void referencecoordinategroup::evalat(int elemtypenum)
 {
     int numintype = 0;
-    for (int i = 0; i < myinputelems.size()/2; i++)
+    for (size_t i = 0; i < myinputelems.size()/2; i++)
     {
         if (myinputelems[2*i+0] == elemtypenum)
             numintype++;
@@ -41,7 +41,7 @@ void referencecoordinategroup::evalat(int elemtypenum)
     std::vector<int> coordnums(numintype);
 
     int index = 0;
-    for (int i = 0; i < myinputelems.size()/2; i++)
+    for (size_t i = 0; i < myinputelems.size()/2; i++)
     {
         if (myinputelems[2*i+0] == elemtypenum)
         {
@@ -95,7 +95,7 @@ void referencecoordinategroup::evalat(std::vector<int>& elems, std::vector<doubl
     std::vector<int> elemscp = elems;
     std::vector<int> coordnumscp = coordnums;
     std::vector<double> kietaphiscp = kietaphis;
-    for (int i = 0; i < elems.size(); i++)
+    for (size_t i = 0; i < elems.size(); i++)
     {
         elems[i] = elemscp[reorderingvector[i]];
         coordnums[i] = coordnumscp[reorderingvector[i]];
@@ -106,7 +106,7 @@ void referencecoordinategroup::evalat(std::vector<int>& elems, std::vector<doubl
 
     // Count the number of elements with a given number of ref coords:
     int maxnumrefcoords = 1; int curnumrefcoords = 1;
-    for (int i = 1; i < elems.size(); i++)
+    for (size_t i = 1; i < elems.size(); i++)
     {
         if (elems[i] == elems[i-1])
         {
@@ -120,7 +120,7 @@ void referencecoordinategroup::evalat(std::vector<int>& elems, std::vector<doubl
     std::vector<int> numelemswithnumrefcoords(maxnumrefcoords+1,0);
     numelemswithnumrefcoords[1] = 1;
     curnumrefcoords = 1;
-    for (int i = 1; i < elems.size(); i++)
+    for (size_t i = 1; i < elems.size(); i++)
     {
         if (elems[i] == elems[i-1])
         {
@@ -148,7 +148,7 @@ void referencecoordinategroup::evalat(std::vector<int>& elems, std::vector<doubl
     }
     std::vector<int> curindexes(maxnumrefcoords+1,0);
     int first = 0;
-    for (int i = 1; i <= elems.size(); i++)
+    for (size_t i = 1; i <= elems.size(); i++)
     {
         if (i < elems.size() && elems[i] == elems[i-1])
             continue;
@@ -181,7 +181,7 @@ void referencecoordinategroup::evalat(std::vector<int>& elems, std::vector<doubl
         std::vector<int> myelemsreordered(myelems[n].size());
         std::vector<int> mycoordnumsreordered(myelems[n].size());
         std::vector<double> mykietaphisreordered(3*myelems[n].size());
-        for (int i = 0; i < reordvec.size(); i++)
+        for (size_t i = 0; i < reordvec.size(); i++)
         {
             myelemsreordered[i] = myelems[n][reordvec[i]];
             mycoordnumsreordered[i] = mycoordnums[n][reordvec[i]];
@@ -192,7 +192,7 @@ void referencecoordinategroup::evalat(std::vector<int>& elems, std::vector<doubl
         // Sort by blocks of n coordinates:
         myalgorithm::stablesort(noisethreshold, mykietaphisreordered, reordvec, 3*n);
     
-        for (int i = 0; i < reordvec.size(); i++)
+        for (size_t i = 0; i < reordvec.size(); i++)
         {
             for (int j = 0; j < n; j++)
             {
@@ -252,7 +252,7 @@ bool referencecoordinategroup::next(void)
     
     // Get the numbers of the reference coordinates:
     mycurcoordnums.resize(numelemsinrange*mynumrefcoords);
-    for (int i = 0; i < mycurcoordnums.size(); i++)
+    for (size_t i = 0; i < mycurcoordnums.size(); i++)
         mycurcoordnums[i] = curcoords->at(myrangebegin+i);
     
 

--- a/src/mesh/regiondefiner.cpp
+++ b/src/mesh/regiondefiner.cpp
@@ -35,7 +35,7 @@ void regiondefiner::defineskinregion(int regnum)
         {
             std::vector<int>* curelemtype = &(curelems->at(elemtype));
 
-            int numelems = curelemtype->size();
+            size_t numelems = curelemtype->size();
             if (numelems == 0)
                 continue;
 
@@ -46,7 +46,7 @@ void regiondefiner::defineskinregion(int regnum)
                 continue;
 
             // Loop on all elements:
-            for (int elem = 0; elem < numelems; elem++)
+            for (size_t elem = 0; elem < numelems; elem++)
             {
                 int curelem = curelemtype->at(elem);
 
@@ -56,7 +56,7 @@ void regiondefiner::defineskinregion(int regnum)
         }
 
         // All single occurences are skin elements:
-        for (int j = 0; j < numoccurences.size(); j++)
+        for (size_t j = 0; j < numoccurences.size(); j++)
         {
             if (numoccurences[j] == 1)
                 newphysreg->addelement(skinelemtype, j);
@@ -100,7 +100,7 @@ void regiondefiner::defineboxregion(int regnum)
                 continue;
 
             // Loop on all elements:
-            for (int elem = 0; elem < curelemtype->size(); elem++)
+            for (size_t elem = 0; elem < curelemtype->size(); elem++)
             {
                 int curelem = curelemtype->at(elem);
 
@@ -169,7 +169,7 @@ void regiondefiner::definesphereregion(int regnum)
                 continue;
 
             // Loop on all elements:
-            for (int elem = 0; elem < curelemtype->size(); elem++)
+            for (size_t elem = 0; elem < curelemtype->size(); elem++)
             {
                 int curelem = curelemtype->at(elem);
 
@@ -209,7 +209,7 @@ void regiondefiner::defineexclusionregion(int regnum)
         
     // Make sure the regions are of same dimension:
     int physregdim = myphysicalregions->get(toexcludefrom[regnum])->getelementdimension();
-    for (int i = 0; i < toexclude[regnum].size(); i++)
+    for (size_t i = 0; i < toexclude[regnum].size(); i++)
     {
         int curdim = myphysicalregions->get(toexclude[regnum][i])->getelementdimension();
         if (curdim != physregdim)
@@ -235,21 +235,21 @@ void regiondefiner::defineexclusionregion(int regnum)
         int numelemsintype = myelements->count(i);
         std::vector<bool> inexcluded(numelemsintype, false);
         // First add all elements from which to exclude:
-        for (int e = 0; e < curelemtype->size(); e++)
+        for (size_t e = 0; e < curelemtype->size(); e++)
             inexcluded[curelemtype->at(e)] = true;
 
         // Now remove the elements to exclude:
-        for (int j = 0; j < toexclude[regnum].size(); j++)
+        for (size_t j = 0; j < toexclude[regnum].size(); j++)
         {
             physicalregion* curtoexclude = myphysicalregions->get(toexclude[regnum][j]);
             std::vector<int>* curelemtypetoexclude = &(curtoexclude->getelementlist()->at(i));
 
-            for (int e = 0; e < curelemtypetoexclude->size(); e++)
+            for (size_t e = 0; e < curelemtypetoexclude->size(); e++)
                 inexcluded[curelemtypetoexclude->at(e)] = false;
         }
 
         // All trues must be added:
-        for (int j = 0; j < inexcluded.size(); j++)
+        for (size_t j = 0; j < inexcluded.size(); j++)
         {
             if (inexcluded[j])
                 newphysreg->addelement(i, j);
@@ -456,7 +456,7 @@ bool regiondefiner::isanyregiondefined(void)
 
 bool regiondefiner::isanycoordinatedependentregiondefined(void)
 {
-    for (int i = 0; i < mypriority.size(); i++)
+    for (size_t i = 0; i < mypriority.size(); i++)
     {
         if (mypriority[i][0] == 1 || mypriority[i][0] == 2)
             return true;
@@ -468,7 +468,7 @@ bool regiondefiner::isanycoordinatedependentregiondefined(void)
 
 void regiondefiner::defineregions(void)
 {
-    for (int i = 0; i < mypriority.size(); i++)
+    for (size_t i = 0; i < mypriority.size(); i++)
     {
         if (mypriority[i][0] == 0)
             defineskinregion(mypriority[i][1]);

--- a/src/mesh/spanningtree.cpp
+++ b/src/mesh/spanningtree.cpp
@@ -8,7 +8,7 @@ void spanningtree::growsubtrees(void)
     isnodeintree = std::vector<bool>(myelements->count(0),false);
 
     numberofsubtrees = 0;
-    for (int i = 0; i < isprioritydisjointregion.size(); i++)
+    for (size_t i = 0; i < isprioritydisjointregion.size(); i++)
     {
         if (isprioritydisjointregion[i] == false)
             continue;
@@ -37,7 +37,7 @@ void spanningtree::growsubtree(int nodenumber, int subtreenumber)
     std::vector<int> edgecandidates = myelements->getedgesonnode(nodenumber);    
 
     // Loop on all edge candidates:
-    for (int i = 0; i < edgecandidates.size(); i++)
+    for (size_t i = 0; i < edgecandidates.size(); i++)
     {
         int currentedge = edgecandidates[i];
 
@@ -79,7 +79,7 @@ void spanningtree::connectsubtrees(void)
 
     // Count the number of edges in each subtree for preallocation:
     std::vector<int> numedgesinsubtree(numberofsubtrees,0);
-    for (int i = 0; i < insubtree.size(); i++)
+    for (size_t i = 0; i < insubtree.size(); i++)
     {
         if (insubtree[i] != -1)
             numedgesinsubtree[insubtree[i]]++;
@@ -90,7 +90,7 @@ void spanningtree::connectsubtrees(void)
         edgesinsubtree[i].resize(numedgesinsubtree[i]);
     // Populate:
     std::vector<int> indexinsubtree(numberofsubtrees,0);
-    for (int i = 0; i < insubtree.size(); i++)
+    for (size_t i = 0; i < insubtree.size(); i++)
     {
         if (insubtree[i] != -1)
         {
@@ -103,7 +103,7 @@ void spanningtree::connectsubtrees(void)
     ///// Create the overall tree by connecting the subtrees:
 
     issubtreeintree = std::vector<bool>(numberofsubtrees,false);
-    for (int i = 0; i < isnodeintree.size(); i++)
+    for (size_t i = 0; i < isnodeintree.size(); i++)
     {
         if (isnodeintree[i] == false)
             growtree(i);
@@ -129,14 +129,14 @@ void spanningtree::growtree(int nodenumber)
     std::vector<int> edgecandidates = myelements->getedgesonnode(nodenumber);    
 
     // Add to the tree all not yet added subtrees on the edges candidates:
-    for (int i = 0; i < edgecandidates.size(); i++)
+    for (size_t i = 0; i < edgecandidates.size(); i++)
     {
         int currentsubtree = insubtree[edgecandidates[i]];
 
         // Add the subtree to the tree if not already added:
         if (currentsubtree != -1 && issubtreeintree[currentsubtree] == false)
         {
-            for (int i = 0; i < edgesinsubtree[currentsubtree].size(); i++)
+            for (size_t i = 0; i < edgesinsubtree[currentsubtree].size(); i++)
             {
                 int node1 = myelements->getsubelement(0, 1, edgesinsubtree[currentsubtree][i], 0);
                 int node2 = myelements->getsubelement(0, 1, edgesinsubtree[currentsubtree][i], 1);
@@ -151,7 +151,7 @@ void spanningtree::growtree(int nodenumber)
             issubtreeintree[currentsubtree] = true;
 
             // Grow tree from every added edge:
-            for (int i = 0; i < edgesinsubtree[currentsubtree].size(); i++)
+            for (size_t i = 0; i < edgesinsubtree[currentsubtree].size(); i++)
             {
                 int node1 = myelements->getsubelement(0, 1, edgesinsubtree[currentsubtree][i], 0);
                 int node2 = myelements->getsubelement(0, 1, edgesinsubtree[currentsubtree][i], 1);
@@ -163,7 +163,7 @@ void spanningtree::growtree(int nodenumber)
     }
 
     // Add to the tree all edges that do not create a loop:
-    for (int i = 0; i < edgecandidates.size(); i++)
+    for (size_t i = 0; i < edgecandidates.size(); i++)
     {
         int currentedge = edgecandidates[i];
 
@@ -192,12 +192,12 @@ void spanningtree::grow(void)
     // Get a vector with all disjoint edge regions in the physical regions provided:
     isprioritydisjointregion = std::vector<bool>(mydisjointregions->count(), false);
 
-    for (int i = 0; i < startphysregs.size(); i++)
+    for (size_t i = 0; i < startphysregs.size(); i++)
     {
         // Get all disjoint edge regions in the current physical region:
         std::vector<int> edgedisjregs = ((universe::mymesh->getphysicalregions())->get(startphysregs[i]))->getdisjointregions(1);
 
-        for (int j = 0; j < edgedisjregs.size(); j++)
+        for (size_t j = 0; j < edgedisjregs.size(); j++)
             isprioritydisjointregion[edgedisjregs[j]] = true;
     }
 

--- a/src/myfft.cpp
+++ b/src/myfft.cpp
@@ -59,7 +59,7 @@ void myfft::removeroundoffnoise(std::vector<std::vector<densematrix>>& input, do
     // First compute the max(abs()) of all harmonics:
     std::vector<double> maxabs(input.size(), 0);
     
-    for (int harm = 1; harm < input.size(); harm++)
+    for (size_t harm = 1; harm < input.size(); harm++)
     {
         if (input[harm].size() > 0)
             maxabs[harm] = input[harm][0].maxabs();
@@ -67,14 +67,14 @@ void myfft::removeroundoffnoise(std::vector<std::vector<densematrix>>& input, do
     
     // Compute the overall harm max:
     double harmmax = 0;
-    for (int i = 1; i < input.size(); i++)
+    for (size_t i = 1; i < input.size(); i++)
     {
         if (maxabs[i] > harmmax)
             harmmax = maxabs[i];
     }
     
     // Kill the too small harmonics:
-    for (int harm = 1; harm < input.size(); harm++)
+    for (size_t harm = 1; harm < input.size(); harm++)
     {
         if (input[harm].size() > 0 && (maxabs[harm] == 0 || maxabs[harm] < threshold*harmmax))
             input[harm] = {};
@@ -93,7 +93,7 @@ densematrix myfft::inversefft(std::vector<std::vector<densematrix>>& input, int 
     densematrix sincoseval(numtimevals,1);
     double* valvec = sincoseval.getvalues();
     
-    for (int harm = 1; harm < input.size(); harm++)
+    for (size_t harm = 1; harm < input.size(); harm++)
     {
         if (input[harm].size() != 0)
         {
@@ -142,20 +142,20 @@ void myfft::sameharmonics(std::vector<std::vector<std::vector<densematrix>>>& no
     if (notsame.size() <= 1)
         return;
 
-    int maxlen = notsame[0].size();
-    for (int i = 1; i < notsame.size(); i++)
+    size_t maxlen = notsame[0].size();
+    for (size_t i = 1; i < notsame.size(); i++)
     {
         if (notsame[i].size() > maxlen)
             maxlen = notsame[i].size();
     }
     // Make sure the length of all notsame[i] is the same:
-    for (int i = 0; i < notsame.size(); i++)
+    for (size_t i = 0; i < notsame.size(); i++)
         notsame[i].resize(maxlen);
         
-    for (int h = 0; h < maxlen; h++)
+    for (size_t h = 0; h < maxlen; h++)
     {
         int curnumrows = -1, curnumcols = -1;
-        for (int i = 0; i < notsame.size(); i++)
+        for (size_t i = 0; i < notsame.size(); i++)
         {
             if (notsame[i][h].size() == 1)
             {
@@ -168,7 +168,7 @@ void myfft::sameharmonics(std::vector<std::vector<std::vector<densematrix>>>& no
             continue;
             
         // Fill with full zero if an entry is missing:
-        for (int i = 0; i < notsame.size(); i++)
+        for (size_t i = 0; i < notsame.size(); i++)
         {
             if (notsame[i][h].size() == 0)
                 notsame[i][h] = {densematrix(curnumrows, curnumcols, 0.0)};

--- a/src/myfft.h
+++ b/src/myfft.h
@@ -36,6 +36,6 @@ namespace myfft
     
     // Make sure notsame[i] has the same harmonic content for every i (fill with zeros if not).
     void sameharmonics(std::vector<std::vector<std::vector<densematrix>>>& notsame);
-};
+}
 
 #endif

--- a/src/resolution/eigenvalue.cpp
+++ b/src/resolution/eigenvalue.cpp
@@ -4,7 +4,7 @@
 void eigenvalue::errorifdirichletnotremoved(std::vector<mat> input)
 {
     // Make sure the Dirichlet constraints have been removed:
-    for (int i = 0; i < input.size(); i++)
+    for (size_t i = 0; i < input.size(); i++)
     {
         if (input[i].getpointer()->getdofmanager()->countconstraineddofs() > 0)
         {
@@ -132,7 +132,7 @@ void eigenvalue::compute(int numeigenvaluestocompute, double targeteigenvaluemag
         PEPCreate( PETSC_COMM_WORLD, &pep );
         
         Mat* petscmats = new Mat[mymats.size()];
-        for (int i = 0; i < mymats.size(); i++)
+        for (size_t i = 0; i < mymats.size(); i++)
             petscmats[i] = mymats[i].getpetsc();
         
         PEPSetOperators( pep, mymats.size(), petscmats );

--- a/src/resolution/genalpha.cpp
+++ b/src/resolution/genalpha.cpp
@@ -113,12 +113,12 @@ int genalpha::run(bool islinear, double timestep, int maxnumnlit)
     std::vector<vec> presols(tosolvebefore.size()), postsols(tosolveafter.size());
     if (istadapt)
     {
-        for (int i = 0; i < presols.size(); i++)
+        for (size_t i = 0; i < presols.size(); i++)
         {
             presols[i] = vec(tosolvebefore[i]);
             presols[i].setdata();
         }
-        for (int i = 0; i < postsols.size(); i++)
+        for (size_t i = 0; i < postsols.size(); i++)
         {
             postsols[i] = vec(tosolveafter[i]);
             postsols[i].setdata();
@@ -259,9 +259,9 @@ int genalpha::run(bool islinear, double timestep, int maxnumnlit)
                 dt *= rfact;
                 // Reset fields for a new resolution:
                 mathop::setdata(u);
-                for (int i = 0; i < presols.size(); i++)
+                for (size_t i = 0; i < presols.size(); i++)
                     mathop::setdata(presols[i]);
-                for (int i = 0; i < postsols.size(); i++)
+                for (size_t i = 0; i < postsols.size(); i++)
                     mathop::setdata(postsols[i]);
             }
                 

--- a/src/resolution/impliciteuler.cpp
+++ b/src/resolution/impliciteuler.cpp
@@ -98,12 +98,12 @@ int impliciteuler::run(bool islinear, double timestep, int maxnumnlit)
     std::vector<vec> presols(tosolvebefore.size()), postsols(tosolveafter.size());
     if (istadapt)
     {
-        for (int i = 0; i < presols.size(); i++)
+        for (size_t i = 0; i < presols.size(); i++)
         {
             presols[i] = vec(tosolvebefore[i]);
             presols[i].setdata();
         }
-        for (int i = 0; i < postsols.size(); i++)
+        for (size_t i = 0; i < postsols.size(); i++)
         {
             postsols[i] = vec(tosolveafter[i]);
             postsols[i].setdata();
@@ -213,9 +213,9 @@ int impliciteuler::run(bool islinear, double timestep, int maxnumnlit)
                 dt *= rfact;
                 // Reset fields for a new resolution:
                 mathop::setdata(x);
-                for (int i = 0; i < presols.size(); i++)
+                for (size_t i = 0; i < presols.size(); i++)
                     mathop::setdata(presols[i]);
-                for (int i = 0; i < postsols.size(); i++)
+                for (size_t i = 0; i < postsols.size(); i++)
                     mathop::setdata(postsols[i]);
             }
                 

--- a/src/shapefunction/hierarchical/hierarchicalformfunction.cpp
+++ b/src/shapefunction/hierarchical/hierarchicalformfunction.cpp
@@ -4,7 +4,7 @@
 int hierarchicalformfunction::gettypenumber(std::string fftypename)
 {
     int outtypenum = -1;
-    for (int i = 0; i < mytypenames.size(); i++)
+    for (size_t i = 0; i < mytypenames.size(); i++)
     {
         if (mytypenames[i] == fftypename)
         {

--- a/src/shapefunction/hierarchical/hierarchicalformfunctioncontainer.cpp
+++ b/src/shapefunction/hierarchical/hierarchicalformfunctioncontainer.cpp
@@ -50,19 +50,19 @@ void hierarchicalformfunctioncontainer::evaluate(std::vector<double> evaluationp
 {
     myevaluationpoints = evaluationpoints;
 
-    for (int h = 0; h < val.size(); h++)
+    for (size_t h = 0; h < val.size(); h++)
     {
-        for (int i = 0; i < val[h].size(); i++)
+        for (size_t i = 0; i < val[h].size(); i++)
         {
-            for (int j = 0; j < val[h][i].size(); j++)
+            for (size_t j = 0; j < val[h][i].size(); j++)
             {
-                for (int k = 0; k < val[h][i][j].size(); k++)
+                for (size_t k = 0; k < val[h][i][j].size(); k++)
                 {
-                    for (int l = 0; l < val[h][i][j][k].size(); l++)
+                    for (size_t l = 0; l < val[h][i][j][k].size(); l++)
                     {
-                        for (int m = 0; m < val[h][i][j][k][l].size(); m++)
+                        for (size_t m = 0; m < val[h][i][j][k][l].size(); m++)
                         {
-                            for (int n = 0; n < val[h][i][j][k][l][m].size(); n++)
+                            for (size_t n = 0; n < val[h][i][j][k][l][m].size(); n++)
                                 val[h][i][j][k][l][m][n] = ffpoly[h][i][j][k][l][n].evalat(evaluationpoints, m);
                         }
                     }
@@ -114,25 +114,25 @@ densematrix hierarchicalformfunctioncontainer::tomatrix(int h, int i, int j, int
 void hierarchicalformfunctioncontainer::print(bool printallderivatives)
 {
     std::cout.precision(17);
-    for (int h = 0; h < val.size(); h++)
+    for (size_t h = 0; h < val.size(); h++)
     {
-        for (int i = 0; i < val[h].size(); i++)
+        for (size_t i = 0; i < val[h].size(); i++)
         {
-            for (int j = 0; j < val[h][i].size(); j++)
+            for (size_t j = 0; j < val[h][i].size(); j++)
             {
-                for (int k = 0; k < val[h][i][j].size(); k++)
+                for (size_t k = 0; k < val[h][i][j].size(); k++)
                 {
-                    for (int l = 0; l < val[h][i][j][k].size(); l++)
+                    for (size_t l = 0; l < val[h][i][j][k].size(); l++)
                     {
-                        for (int m = 0; m < val[h][i][j][k][l].size(); m++)
+                        for (size_t m = 0; m < val[h][i][j][k][l].size(); m++)
                         {
                             if (not(printallderivatives) && m > 0)
                                 continue;
                             
-                            for (int n = 0; n < val[h][i][j][k][l][m].size(); n++)
+                            for (size_t n = 0; n < val[h][i][j][k][l][m].size(); n++)
                             {
                                 std::cout << "order " << h << "; dim " << i << "; sub elem index " << j << "; orientation " << k << "; number " << l << "; derivative " << m << "; comp " << n << ": ";
-                                for (int o = 0; o < val[h][i][j][k][l][m][n].size(); o++)
+                                for (size_t o = 0; o < val[h][i][j][k][l][m][n].size(); o++)
                                     std::cout << val[h][i][j][k][l][m][n][o] << " ";
                                 std::cout << std::endl;
                             }

--- a/src/shapefunction/hierarchical/legendre.h
+++ b/src/shapefunction/hierarchical/legendre.h
@@ -25,6 +25,6 @@ namespace legendre
     std::vector<polynomial> ls(int maxn, polynomial x, polynomial t);
     // Scaled integrated Legendre polynomials Ls(x,t):
     std::vector<polynomial> Ls(int maxn, polynomial x, polynomial t);
-};
+}
 
 #endif

--- a/src/shapefunction/hierarchical/orientation.h
+++ b/src/shapefunction/hierarchical/orientation.h
@@ -100,6 +100,6 @@ namespace orientation
     int getorientationofedge(std::vector<int>& physicalnodesinedge);
     int getorientationoftriangle(std::vector<int>& physicalnodesintriangle);
     int getorientationofquadrangle(std::vector<int>& physicalnodesinquadrangle);
-};
+}
 
 #endif

--- a/src/shapefunction/hierarchical/selector.h
+++ b/src/shapefunction/hierarchical/selector.h
@@ -39,6 +39,6 @@ namespace selector
 {
     // Get a pointer to the selected form function:
     std::shared_ptr<hierarchicalformfunction> select(int elementtypenumber, std::string formfunctiontypename);
-};
+}
 
 #endif

--- a/src/shapefunction/polynomial.cpp
+++ b/src/shapefunction/polynomial.cpp
@@ -8,11 +8,11 @@ void polynomial::set(const std::vector<std::vector<std::vector<double>>>& coeffi
 
 void polynomial::print(void)
 {
-    for (int kiorder = 0; kiorder < mycoefficients.size(); kiorder++)
+    for (size_t kiorder = 0; kiorder < mycoefficients.size(); kiorder++)
     {
-        for (int etaorder = 0; etaorder < mycoefficients[kiorder].size(); etaorder++)
+        for (size_t etaorder = 0; etaorder < mycoefficients[kiorder].size(); etaorder++)
         {
-            for (int phiorder = 0; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
+            for (size_t phiorder = 0; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
             {
                 double currentcoef = mycoefficients[kiorder][etaorder][phiorder];
                 // Skip 0 coefficients:
@@ -55,9 +55,9 @@ void polynomial::print(void)
 
 std::vector<double> polynomial::evalat(const std::vector<double>& evaluationpoints, int whichderivative)
 {
-    int firstkiorder = 0;
-    int firstetaorder = 0;
-    int firstphiorder = 0;
+    size_t firstkiorder = 0;
+    size_t firstetaorder = 0;
+    size_t firstphiorder = 0;
     if (whichderivative == 1)
         firstkiorder = 1;
     if (whichderivative == 2)
@@ -78,13 +78,13 @@ std::vector<double> polynomial::evalat(const std::vector<double>& evaluationpoin
         double kipower = 1;
     
         // Loop on all coefficients:
-        for (int kiorder = firstkiorder; kiorder < mycoefficients.size(); kiorder++)
+        for (size_t kiorder = firstkiorder; kiorder < mycoefficients.size(); kiorder++)
         {        
             double etapower = 1;
-            for (int etaorder = firstetaorder; etaorder < mycoefficients[kiorder].size(); etaorder++)
+            for (size_t etaorder = firstetaorder; etaorder < mycoefficients[kiorder].size(); etaorder++)
             {
                 double phipower = 1;
-                for (int phiorder = firstphiorder; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
+                for (size_t phiorder = firstphiorder; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
                 {
                     // Skip zero coefficients:
                     if (mycoefficients[kiorder][etaorder][phiorder] != 0)
@@ -162,14 +162,14 @@ polynomial polynomial::operator+(polynomial toadd)
         output.mycoefficients.resize(toadd.mycoefficients.size());
             
     // Loop on all coefficients of 'toadd':
-    for (int kiorder = 0; kiorder < toadd.mycoefficients.size(); kiorder++)
+    for (size_t kiorder = 0; kiorder < toadd.mycoefficients.size(); kiorder++)
     {        
-        for (int etaorder = 0; etaorder < toadd.mycoefficients[kiorder].size(); etaorder++)
+        for (size_t etaorder = 0; etaorder < toadd.mycoefficients[kiorder].size(); etaorder++)
         {
             if (output.mycoefficients[kiorder].size() < toadd.mycoefficients[kiorder].size())
                 output.mycoefficients[kiorder].resize(toadd.mycoefficients[kiorder].size());
                 
-            for (int phiorder = 0; phiorder < toadd.mycoefficients[kiorder][etaorder].size(); phiorder++)
+            for (size_t phiorder = 0; phiorder < toadd.mycoefficients[kiorder][etaorder].size(); phiorder++)
             {
                 if (output.mycoefficients[kiorder][etaorder].size() < toadd.mycoefficients[kiorder][etaorder].size())
                     output.mycoefficients[kiorder][etaorder].resize(toadd.mycoefficients[kiorder][etaorder].size());
@@ -189,14 +189,14 @@ polynomial polynomial::operator-(polynomial tosubtract)
         output.mycoefficients.resize(tosubtract.mycoefficients.size());
             
     // Loop on all coefficients of 'tosubtract':
-    for (int kiorder = 0; kiorder < tosubtract.mycoefficients.size(); kiorder++)
+    for (size_t kiorder = 0; kiorder < tosubtract.mycoefficients.size(); kiorder++)
     {        
-        for (int etaorder = 0; etaorder < tosubtract.mycoefficients[kiorder].size(); etaorder++)
+        for (size_t etaorder = 0; etaorder < tosubtract.mycoefficients[kiorder].size(); etaorder++)
         {
             if (output.mycoefficients[kiorder].size() < tosubtract.mycoefficients[kiorder].size())
                 output.mycoefficients[kiorder].resize(tosubtract.mycoefficients[kiorder].size());
                 
-            for (int phiorder = 0; phiorder < tosubtract.mycoefficients[kiorder][etaorder].size(); phiorder++)
+            for (size_t phiorder = 0; phiorder < tosubtract.mycoefficients[kiorder][etaorder].size(); phiorder++)
             {
                 if (output.mycoefficients[kiorder][etaorder].size() < tosubtract.mycoefficients[kiorder][etaorder].size())
                     output.mycoefficients[kiorder][etaorder].resize(tosubtract.mycoefficients[kiorder][etaorder].size());
@@ -218,11 +218,11 @@ polynomial polynomial::operator-()
     polynomial output = *this;
     
     // Loop on all coefficients:
-    for (int kiorder = 0; kiorder < mycoefficients.size(); kiorder++)
+    for (size_t kiorder = 0; kiorder < mycoefficients.size(); kiorder++)
     {
-        for (int etaorder = 0; etaorder < mycoefficients[kiorder].size(); etaorder++)
+        for (size_t etaorder = 0; etaorder < mycoefficients[kiorder].size(); etaorder++)
         {
-            for (int phiorder = 0; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
+            for (size_t phiorder = 0; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
             {
                 // Flip the sign of the coefficient:
                 output.mycoefficients[kiorder][etaorder][phiorder] = -mycoefficients[kiorder][etaorder][phiorder];
@@ -237,11 +237,11 @@ polynomial polynomial::operator*(double val)
     polynomial output = *this;
     
     // Loop on all coefficients:
-    for (int kiorder = 0; kiorder < mycoefficients.size(); kiorder++)
+    for (size_t kiorder = 0; kiorder < mycoefficients.size(); kiorder++)
     {
-        for (int etaorder = 0; etaorder < mycoefficients[kiorder].size(); etaorder++)
+        for (size_t etaorder = 0; etaorder < mycoefficients[kiorder].size(); etaorder++)
         {
-            for (int phiorder = 0; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
+            for (size_t phiorder = 0; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
             {
                 // Multiply the coefficient by 'val':
                 output.mycoefficients[kiorder][etaorder][phiorder] = val*mycoefficients[kiorder][etaorder][phiorder];
@@ -284,16 +284,16 @@ polynomial polynomial::operator-(double val)
 void polynomial::dki(void)
 {
     // Shift all ki vectors back down one order - dump order 0 in ki:
-    for (int kiorder = 1; kiorder < mycoefficients.size(); kiorder++)
+    for (size_t kiorder = 1; kiorder < mycoefficients.size(); kiorder++)
         mycoefficients[kiorder-1] = mycoefficients[kiorder];
     if (mycoefficients.size() > 0)
         mycoefficients.pop_back();
     // One also has to take into account the extra factor coming from a derivative:    
-    for (int kiorder = 1; kiorder < mycoefficients.size(); kiorder++)
+    for (size_t kiorder = 1; kiorder < mycoefficients.size(); kiorder++)
     {
-        for (int etaorder = 0; etaorder < mycoefficients[kiorder].size(); etaorder++)
+        for (size_t etaorder = 0; etaorder < mycoefficients[kiorder].size(); etaorder++)
         {
-            for (int phiorder = 0; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
+            for (size_t phiorder = 0; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
                 mycoefficients[kiorder][etaorder][phiorder] = (kiorder+1) * mycoefficients[kiorder][etaorder][phiorder];
         }
     }
@@ -302,16 +302,16 @@ void polynomial::dki(void)
 void polynomial::deta(void)
 {
     // Shift all eta vectors back down one order - dump order 0 in eta:
-    for (int kiorder = 0; kiorder < mycoefficients.size(); kiorder++)
+    for (size_t kiorder = 0; kiorder < mycoefficients.size(); kiorder++)
     {
-        for (int etaorder = 1; etaorder < mycoefficients[kiorder].size(); etaorder++)
+        for (size_t etaorder = 1; etaorder < mycoefficients[kiorder].size(); etaorder++)
             mycoefficients[kiorder][etaorder-1] = mycoefficients[kiorder][etaorder];
         if (mycoefficients[kiorder].size() > 0)
             mycoefficients[kiorder].pop_back();
         // One also has to take into account the extra factor coming from a derivative:    
-        for (int etaorder = 1; etaorder < mycoefficients[kiorder].size(); etaorder++)
+        for (size_t etaorder = 1; etaorder < mycoefficients[kiorder].size(); etaorder++)
         {
-            for (int phiorder = 0; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
+            for (size_t phiorder = 0; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
                 mycoefficients[kiorder][etaorder][phiorder] = (etaorder+1) * mycoefficients[kiorder][etaorder][phiorder];
         }
     }
@@ -320,16 +320,16 @@ void polynomial::deta(void)
 void polynomial::dphi(void)
 {
     // Shift all phi vectors back down one order - dump order 0 in phi:
-    for (int kiorder = 0; kiorder < mycoefficients.size(); kiorder++)
+    for (size_t kiorder = 0; kiorder < mycoefficients.size(); kiorder++)
     {
-        for (int etaorder = 0; etaorder < mycoefficients[kiorder].size(); etaorder++)
+        for (size_t etaorder = 0; etaorder < mycoefficients[kiorder].size(); etaorder++)
         {
-            for (int phiorder = 1; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
+            for (size_t phiorder = 1; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
                 mycoefficients[kiorder][etaorder][phiorder-1] = mycoefficients[kiorder][etaorder][phiorder];
             if (mycoefficients[kiorder][etaorder].size() > 0)
                 mycoefficients[kiorder][etaorder].pop_back();
             // One also has to take into account the extra factor coming from a derivative:    
-            for (int phiorder = 1; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
+            for (size_t phiorder = 1; phiorder < mycoefficients[kiorder][etaorder].size(); phiorder++)
                 mycoefficients[kiorder][etaorder][phiorder] = (phiorder+1) * mycoefficients[kiorder][etaorder][phiorder];
         }
     }

--- a/src/shapefunction/polynomials.cpp
+++ b/src/shapefunction/polynomials.cpp
@@ -32,11 +32,11 @@ polynomials::polynomials(std::vector<polynomial> input)
     mycoeffs = std::vector<double>(mynumpolys * mynummonomials, 0.0);
     for (int pol = 0; pol < mynumpolys; pol++)
     {
-        for (int k = 0; k < input[pol].mycoefficients.size(); k++)
+        for (size_t k = 0; k < input[pol].mycoefficients.size(); k++)
         {
-            for (int e = 0; e < input[pol].mycoefficients[k].size(); e++)
+            for (size_t e = 0; e < input[pol].mycoefficients[k].size(); e++)
             {
-                for (int p = 0; p < input[pol].mycoefficients[k][e].size(); p++)
+                for (size_t p = 0; p < input[pol].mycoefficients[k][e].size(); p++)
                     mycoeffs[pol*mynummonomials+k*myetalen*myphilen+e*myphilen+p] = input[pol].mycoefficients[k][e][p];
             }
         }
@@ -167,7 +167,7 @@ void polynomials::print(void)
 {
     std::cout << "Number of polynomials is " << mynumpolys << " with " << mynummonomials << " monomials (" << mykilen << "x" << myetalen << "x" << myphilen << ")" << std::endl;
     std::cout << "Coefficients are:" << std::endl;
-    for (int i = 0; i < mycoeffs.size(); i++)
+    for (size_t i = 0; i < mycoeffs.size(); i++)
         std::cout << mycoeffs[i] << " ";
     std::cout << std::endl;
 }

--- a/src/shapefunction/spline.cpp
+++ b/src/shapefunction/spline.cpp
@@ -18,7 +18,7 @@ spline::spline(std::string filename, char delimiter)
     std::vector<double> xin(data.size()/2);
     std::vector<double> yin(data.size()/2);
     
-    for (int i = 0; i < data.size()/2; i++)
+    for (size_t i = 0; i < data.size()/2; i++)
     {
         xin[i] = data[2*i+0];
         yin[i] = data[2*i+1];

--- a/src/universe.cpp
+++ b/src/universe.cpp
@@ -76,7 +76,7 @@ std::vector< densematrix > universe::opcomputedfft = {};
 
 int universe::getindexofprecomputedvalue(std::shared_ptr<operation> op)
 {
-    for (int i = 0; i < oppointers.size(); i++)
+    for (size_t i = 0; i < oppointers.size(); i++)
     {
         if (oppointers[i].get() == op.get())
             return i;
@@ -86,7 +86,7 @@ int universe::getindexofprecomputedvalue(std::shared_ptr<operation> op)
 
 int universe::getindexofprecomputedvaluefft(std::shared_ptr<operation> op)
 {
-    for (int i = 0; i < oppointersfft.size(); i++)
+    for (size_t i = 0; i < oppointersfft.size(); i++)
     {
         if (oppointersfft[i].get() == op.get())
             return i;
@@ -97,7 +97,7 @@ int universe::getindexofprecomputedvaluefft(std::shared_ptr<operation> op)
 std::vector<std::vector<densematrix>> universe::getprecomputed(int index)
 {
     std::vector<std::vector<densematrix>> output = opcomputed[index];
-    for (int h = 0; h < output.size(); h++)
+    for (size_t h = 0; h < output.size(); h++)
     {
         if (output[h].size() == 1)
             output[h][0] = output[h][0].copy();
@@ -114,7 +114,7 @@ void universe::setprecomputed(std::shared_ptr<operation> op, std::vector<std::ve
 {
     oppointers.push_back(op);
     opcomputed.push_back(val);
-    for (int h = 0; h < val.size(); h++)
+    for (size_t h = 0; h < val.size(); h++)
     {
         if (val[h].size() == 1)
             opcomputed[opcomputed.size()-1][h][0] = val[h][0].copy();
@@ -140,7 +140,7 @@ hierarchicalformfunctioncontainer* universe::gethff(std::string fftypename, int 
 {
     // Find the type name in the container:
     int typenameindex = -1;
-    for (int i = 0; i < formfuncpolys.size(); i++)
+    for (size_t i = 0; i < formfuncpolys.size(); i++)
     {
         if (formfuncpolys[i].first == fftypename)
         {
@@ -185,11 +185,11 @@ hierarchicalformfunctioncontainer* universe::gethff(std::string fftypename, int 
 
 void universe::resethff(void)
 {
-    for (int typenameindex = 0; typenameindex < formfuncpolys.size(); typenameindex++)
+    for (size_t typenameindex = 0; typenameindex < formfuncpolys.size(); typenameindex++)
     {
-        for (int elementtypenumber = 0; elementtypenumber < (formfuncpolys[typenameindex].second).size(); elementtypenumber++)
+        for (size_t elementtypenumber = 0; elementtypenumber < (formfuncpolys[typenameindex].second).size(); elementtypenumber++)
         {
-            for (int interpolorder = 0; interpolorder < formfuncpolys[typenameindex].second[elementtypenumber].size(); interpolorder++)
+            for (size_t interpolorder = 0; interpolorder < formfuncpolys[typenameindex].second[elementtypenumber].size(); interpolorder++)
             {
                 if (formfuncpolys[typenameindex].second[elementtypenumber][interpolorder].size() > 0)
                     formfuncpolys[typenameindex].second[elementtypenumber][interpolorder][0].setvaluestatus(false);


### PR DESCRIPTION
Building with warnings enables gives a lot of warnings to the user. This is a first PR to fix the most outstanding ones to reduce the build noise quite a bit:

* remove useless semicolons after namespace blocks / function definitions
* change int -> size_t in case we iterate over a std::vector to avoid signed/unsigned comparison as long as iterator can never be negative
  *  I skipped loops which contain `size()-1`, because those would need to be rewritten to not introduce a regessions for size==0.
