### PR TITLE
Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,26 @@ In order to create a new simulation:
 1. Replace target name `default` with the unique one in `simulations/newsim/CMakeLists.txt`
 1. Add line `add_subdirectory(newsim)` to the `simulations/CMakeLists.txt`
 1. Build as usual. Executable file will be located in `build/simulations/newsim` folder
+
+# Docker image
+
+With [Docker](https://www.docker.com/) you can run your simulations using containerized development
+environment.
+
+Run your simulation in three steps:
+
+1. Install [Docker](https://docs.docker.com/engine/install/)
+1. Create image:
+   ```bash
+   docker build -t sparselizard_debian_testing:latest -f docker/debian-testing.dockerfile  .
+   ```
+1. Build:
+   ```bash
+   docker run -it --rm -v "$(pwd):/workdir" sparselizard_debian_testing
+   ```
+
+*Notes:*
+* Docker container is running in interactive mode, so you can interrupt it from keyboard
+* By default UID 1000 is used. It may be adjusted in `docker/debian-testing.dockerfile`
+* Binaries and libraries created using Docker container are linked inside this container and cannot
+  be used without it

--- a/docker/buildscript.sh
+++ b/docker/buildscript.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_EXAMPLES=NO \
+    && cmake --build build -j $(nproc) \
+    && cd build/simulations/default \
+    && ./default
+

--- a/docker/debian-testing.dockerfile
+++ b/docker/debian-testing.dockerfile
@@ -1,0 +1,26 @@
+FROM debian:testing
+
+# install fonts and basic programs
+RUN apt-get update -q \
+        && DEBIAN_FRONTEND=noninteractive \
+        apt-get install -qy --no-install-recommends --no-install-suggests \
+        g++ \
+        make \
+        cmake \
+        libopenblas-dev \
+        libgmsh-dev \
+        libmetis-dev \
+        libopenmpi-dev \
+        libpetsc-real-dev \
+        libslepc-real-dev \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
+
+# source directory shell be mounted here
+WORKDIR /workdir
+VOLUME /workdir
+
+RUN useradd --uid 1000 --no-create-home --shell /bin/bash builduser
+USER builduser
+
+ENTRYPOINT docker/buildscript.sh


### PR DESCRIPTION
Add docker container for Debian testing.
It can be used for running simulations without installation of dependency libraries (but docker is required).

Official image may be pushed to hub.docker.com so that users would be able to pull it instead of creating by themselves.