### PR TITLE
Add line break to impliciteuler for easier to read output

### DIFF
--- a/src/resolution/impliciteuler.cpp
+++ b/src/resolution/impliciteuler.cpp
@@ -236,6 +236,8 @@ int impliciteuler::run(bool islinear, double timestep, int maxnumnlit)
     dtx = dtxnext;
     mytimes.push_back(universe::currenttimestep);
     
+    std::cout << std::endl;
+    
     return nlit;
 }
 


### PR DESCRIPTION
Output for each timestep is printed on a new line.  This change appears to work for all combinations of linear, non-linear, fixed timestep, and adaptive timestep.

Before commit:
![sl impliciteuler wo endl](https://user-images.githubusercontent.com/49321778/108417195-a7c06300-71fd-11eb-8e34-780a18837c68.png)

After commit:
![sl impliciteuler w endl](https://user-images.githubusercontent.com/49321778/108417213-b0189e00-71fd-11eb-8c05-03f030e45642.png)
