### PR TITLE
petsc branch name changed to 'main'

### DIFF
--- a/install_external_libs/install_petsc.sh
+++ b/install_external_libs/install_petsc.sh
@@ -17,7 +17,7 @@ cd ~/SLlibs;
 
 echo '__________________________________________';
 echo 'FETCHING THE LATEST PETSC VERSION FROM GIT';
-git clone -b master https://gitlab.com/petsc/petsc.git petsc;
+git clone -b main https://gitlab.com/petsc/petsc.git petsc;
 
 
 ########## CONFIGURE PETSC (SELECT THE APPROPRIATE CONFIGURATION OPTIONS BELOW) :


### PR DESCRIPTION
It appears petsc changed branch name from 'master' to 'main'.