### PR TITLE
Add install rule to cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,3 +70,7 @@ endif()
 
 target_include_directories(sparselizard PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
+install(TARGETS sparselizard)
+install(DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/include/"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sparselizard"
+        FILES_MATCHING PATTERN "*.h")


### PR DESCRIPTION
This enables us to install sparselizard onto the system so it is found like a system library.

Please note, when using `install_external_libs` that the library paths are not installed and have to be manually added to the search-path for now. In case system libraries are used everything should work out-of-the-box.

To install the library as well as all include files, just enter ```sudo make install``` after the build

To include sparselizard, write:

```c
#include <sparselizard/sparselizard.h>
```

I added the include directory to ensure that no name-clash with already existing include files will happen.

---

For documentation how to build and run applications when using `install_external_libs` instead of system libraries:

```bash
cd examples/data-saving

# The option `-I /usr/local/include/sparselizard` is only there to allow #include "sparselizard.h"
g++ -I /usr/local/include/sparselizard \
       -I ~/SLlibs/petsc/include \
       -I ~/SLlibs/petsc/arch-linux-c-opt/include \
       -L ~/SLlibs/petsc/arch-linux-c-opt/lib \
       -L ~/SLlibs/gmsh/lib \
       -lsparselizard main.cpp -o data-saving

# explicitly add library paths for executable of libraries not in the default search-path. Not required for system libraries
export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:~/SLlibs/petsc/arch-linux-c-opt/lib:~/SLlibs/gmsh/lib
./data-saving
```