### PR TITLE
Drop the global using namespace std from a public header

### DIFF
--- a/src/shapefunction/hierarchical/hierarchicalformfunctioncontainer.h
+++ b/src/shapefunction/hierarchical/hierarchicalformfunctioncontainer.h
@@ -14,8 +14,6 @@
 #include "polynomial.h"
 #include "orientation.h"
 
-using namespace std;
-
 class hierarchicalformfunctioncontainer
 {
 
@@ -39,10 +37,10 @@ class hierarchicalformfunctioncontainer
         // - for derivative ki if m is 1, eta 2, phi 3, none 0
         // - at component n (0 for x, 1 for y and 2 for z)
         // - evaluation point o
-        vector<vector<vector<vector<vector<vector<vector<vector<double>>>>>>>> val = {};
-        
+        std::vector<std::vector<std::vector<std::vector<std::vector<std::vector<std::vector<std::vector<double>>>>>>>> val = {};
+
         // The form function polynomials are stored in the same format but without [m] and [o]:
-        vector<vector<vector<vector<vector<vector<polynomial>>>>>> ffpoly = {};
+        std::vector<std::vector<std::vector<std::vector<std::vector<std::vector<polynomial>>>>>> ffpoly = {};
 
     public:
 


### PR DESCRIPTION
## Problem

`src/shapefunction/hierarchical/hierarchicalformfunctioncontainer.h` opens the `std` namespace at
global scope. The header is pulled in by `rawfield.h`, so every translation unit that includes
`sparselizard.h` inherits it.

Under `-std=c++20` that makes `sl::integral` ambiguous with the `std::integral` concept, and any
example using `integral()` stops compiling:

```
error C2872: 'integral': ambiguous symbol
error C3245: 'std::integral': use of a variable template requires a template argument list
```

## What changes

The directive was vestigial: the header already qualified `std::string` and `std::vector`
everywhere except the two members below it. Those two are qualified and the directive removed,
which is the whole change.

## Checks

A full build of the library is unchanged, so nothing depended on the directive leaking out of the
header. An application that includes `sparselizard.h` then compiles at `/std:c++20`, where it
previously could not.